### PR TITLE
Enhance income tracking and visualization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 // src/App.jsx
 import React, { useState } from 'react'
-import { useFinance } from './FinanceContext.jsx'
 import IncomeTab from './IncomeTab'
 import ExpensesGoalsTab from './ExpensesGoalsTab'
 import BalanceSheetTab from './BalanceSheetTab'

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -25,7 +25,6 @@ export default function ExpensesGoalsTab() {
     expensesList, setExpensesList,
     goalsList,    setGoalsList,
     liabilitiesList, setLiabilitiesList,
-    setMonthlyExpense,
     setExpensesPV,
     profile,
     settings
@@ -170,7 +169,10 @@ export default function ExpensesGoalsTab() {
       assumptions: { discountRate, lifeYears },
       expenses:      expensesList, pvExpenses: pvExpensesLife,
       goals:         goalsList,    pvGoals,
-      liabilities:   liabilityDetails.map(({ schedule, ...l }) => l),
+      liabilities:   liabilityDetails.map(l => {
+        const { schedule: _unused, ...rest } = l;
+        return rest;
+      }),
       totalLiabilitiesPV, totalRequired
     }
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -15,7 +15,16 @@ export function FinanceProvider({ children }) {
   // === IncomeTab state ===
   const [incomeSources, setIncomeSources] = useState(() => {
     const s = localStorage.getItem('incomeSources')
-    return s ? JSON.parse(s) : [{ name:'Salary',amount:10000,frequency:12,growth:5 }]
+    return s
+      ? JSON.parse(s)
+      : [{
+          name: 'Salary',
+          type: 'Employment',
+          amount: 10000,
+          frequency: 12,
+          growth: 5,
+          taxRate: 30,
+        }]
   })
   const [startYear, setStartYear] = useState(() => {
     const s = localStorage.getItem('incomeStartYear')

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global module, require */
 module.exports = {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {


### PR DESCRIPTION
## Summary
- extend income objects with `type` and `taxRate`
- support after‑tax PV calculations and interruption modeling
- add monthly/yearly chart toggle and interruption selector
- improve form inputs with validation, animations and placeholder text
- implement CSV export and print button
- show survival status badge
- clean up lint warnings

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68430df984e8832398ca8cc7b6340135