### PR TITLE
Standardize expense frequency strings

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -125,7 +125,9 @@ export function FinanceProvider({ children }) {
   }, [expensesList])
 
   useEffect(() => {
-    const freqMap = { Monthly: 12, Quarterly: 4, Annually: 1, Annual: 1, OneTime: 0 }
+    // Supported expense frequencies match the dropdown in
+    // ExpensesGoalsTab.jsx
+    const freqMap = { Monthly: 12, Annual: 1, OneTime: 0 }
     const totalPv = expensesList.reduce((sum, exp) => {
       const paymentsPerYear = freqMap[exp.frequency] ?? 1
       return sum + calculatePV(

--- a/src/__tests__/calculatePVFrequency.test.js
+++ b/src/__tests__/calculatePVFrequency.test.js
@@ -1,0 +1,17 @@
+/* global test, expect */
+import { calculatePV } from '../utils/financeUtils'
+
+test('calculatePV handles supported frequencies', () => {
+  const amount = 100
+  const growth = 0
+  const discount = 5
+  const years = 3
+
+  const monthly = calculatePV(amount, 12, growth, discount, years)
+  const annual = calculatePV(amount, 1, growth, discount, years)
+  const oneTime = calculatePV(amount, 0, growth, discount, years)
+
+  expect(monthly).toBeGreaterThan(annual)
+  expect(annual).toBeGreaterThan(0)
+  expect(oneTime).toBe(0)
+})


### PR DESCRIPTION
## Summary
- align expense frequency dropdown and PV calculations
- remove unused Quarterly/Annually options
- test calculatePV across supported frequencies

## Testing
- `CI=true npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68432acb55788323af05dabb2d6b5e9a