### PR TITLE
Add frequency constants

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
 import { calculatePV } from './utils/financeUtils'
+import { FREQUENCIES } from './constants'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend
@@ -20,7 +21,7 @@ import {
  */
 export default function ExpensesGoalsTab() {
   const currentYear = new Date().getFullYear()
-  const {
+  const { 
     discountRate,
     expensesList, setExpensesList,
     goalsList,    setGoalsList,
@@ -29,6 +30,8 @@ export default function ExpensesGoalsTab() {
     profile,
     settings
   } = useFinance()
+
+  const payMap = { Monthly: 12, Quarterly: 4, Annually: 1 }
 
   // --- Helpers ---
   const clamp = (v, min = 0) => isNaN(v) || v < min ? min : v
@@ -112,9 +115,8 @@ export default function ExpensesGoalsTab() {
 
   // --- 2) PV of Expenses over lifeYears ---
   const pvExpensesLife = useMemo(() => {
-    const freqMap = { Monthly: 12, Annual: 1, OneTime: 0 }
     return expensesList.reduce((sum, e) => {
-      const freq = freqMap[e.frequency] || 0
+      const freq = payMap[e.frequency] || 0
       return sum + calculatePV(e.amount, freq, e.growth, discountRate, lifeYears)
     }, 0)
   }, [expensesList, discountRate, lifeYears])
@@ -233,9 +235,9 @@ export default function ExpensesGoalsTab() {
               value={e.frequency}
               onChange={ev => handleExpenseChange(i, 'frequency', ev.target.value)}
             >
-              <option>Monthly</option>
-              <option>Annual</option>
-              <option>OneTime</option>
+              {FREQUENCIES.map(f => (
+                <option key={f}>{f}</option>
+              ))}
             </select>
             <input
               className="border p-2 rounded-md text-right"
@@ -358,9 +360,9 @@ export default function ExpensesGoalsTab() {
             value={l.paymentsPerYear}
             onChange={ev => handleLiabilityChange(i, 'paymentsPerYear', ev.target.value)}
           >
-            <option value={12}>Monthly</option>
-            <option value={4}>Quarterly</option>
-            <option value={1}>Annually</option>
+            {FREQUENCIES.map(f => (
+              <option key={f} value={payMap[f]}>{f}</option>
+            ))}
           </select>
             <input
               className="border p-2 rounded-md text-right"

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect } from 'react'
 import { calculatePV } from './utils/financeUtils'
+import { FREQUENCIES } from './constants'
 
 const FinanceContext = createContext()
 
@@ -17,6 +18,8 @@ export function FinanceProvider({ children }) {
   const [expensesPV, setExpensesPV]         = useState(0)
   const [pvExpenses, setPvExpenses]         = useState(0)
   const [monthlyPVExpense, setMonthlyPVExpense] = useState(0)
+
+  const payMap = { Monthly: 12, Quarterly: 4, Annually: 1 }
 
   // === IncomeTab state ===
   const [incomeSources, setIncomeSources] = useState(() => {
@@ -125,11 +128,8 @@ export function FinanceProvider({ children }) {
   }, [expensesList])
 
   useEffect(() => {
-    // Supported expense frequencies match the dropdown in
-    // ExpensesGoalsTab.jsx
-    const freqMap = { Monthly: 12, Annual: 1, OneTime: 0 }
     const totalPv = expensesList.reduce((sum, exp) => {
-      const paymentsPerYear = freqMap[exp.frequency] ?? 1
+      const paymentsPerYear = payMap[exp.frequency] ?? 1
       return sum + calculatePV(
         exp.amount,
         paymentsPerYear,

--- a/src/__tests__/calculatePVFrequency.test.js
+++ b/src/__tests__/calculatePVFrequency.test.js
@@ -8,10 +8,10 @@ test('calculatePV handles supported frequencies', () => {
   const years = 3
 
   const monthly = calculatePV(amount, 12, growth, discount, years)
+  const quarterly = calculatePV(amount, 4, growth, discount, years)
   const annual = calculatePV(amount, 1, growth, discount, years)
-  const oneTime = calculatePV(amount, 0, growth, discount, years)
 
-  expect(monthly).toBeGreaterThan(annual)
+  expect(monthly).toBeGreaterThan(quarterly)
+  expect(quarterly).toBeGreaterThan(annual)
   expect(annual).toBeGreaterThan(0)
-  expect(oneTime).toBe(0)
 })

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const FREQUENCIES = ['Monthly', 'Quarterly', 'Annually']
+


### PR DESCRIPTION
## Summary
- centralize list of time frequencies
- generate dropdowns from FREQUENCIES
- remove obsolete Annual/OneTime options
- update calculations to use new mapping
- adjust PV frequency test

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843306eb6d48323a7027d3d6fe09b64