### PR TITLE
Validate life expectancy vs age

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -114,7 +114,7 @@ export default function ExpensesGoalsTab() {
     setLiabilitiesList(liabilitiesList.filter((_, idx) => idx !== i))
 
   // --- 1) Remaining lifetime horizon ---
-  const lifeYears = Math.max(0, Math.floor(profile.lifeExpectancy - profile.age))
+  const lifeYears = Math.max(1, Math.floor(profile.lifeExpectancy - profile.age))
 
   // --- 2) PV of Expenses over lifeYears ---
   const pvExpensesLife = useMemo(() => {

--- a/src/ProfileTab.jsx
+++ b/src/ProfileTab.jsx
@@ -18,6 +18,8 @@ export default function ProfileTab() {
     updateProfile(updated)
   }
 
+  const remainingYears = form.lifeExpectancy - form.age
+
   // Map numeric riskScore to a category label
   const scoreCategory = (s) => {
     if (s <= 6) return 'Conservative'
@@ -50,6 +52,7 @@ export default function ProfileTab() {
             ['Email Address', 'email', 'email'],
             ['Phone Number', 'phone', 'tel'],
             ['Age', 'age', 'number'],
+            ['Life Expectancy', 'lifeExpectancy', 'number'],
             ['Marital Status', 'maritalStatus', 'select', ['', 'Single', 'Married', 'Divorced', 'Widowed']],
             ['Dependents', 'numDependents', 'number']
           ].map(([label, field, type, options]) => (
@@ -82,6 +85,9 @@ export default function ProfileTab() {
               )}
             </label>
           ))}
+          {remainingYears <= 0 && (
+            <p className="text-red-600 text-sm">Life expectancy must exceed age.</p>
+          )}
 
           {[
             ['Residential Address', 'residentialAddress'],


### PR DESCRIPTION
## Summary
- ensure remaining lifetime is at least 1 year
- add life expectancy to the profile form
- warn when life expectancy is less than or equal to age

## Testing
- `npx jest --runInBand`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843343a2e18832387d29303f6952551