### PR TITLE
Remove OneTime from expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Personal Finance App
 
-This web application helps you manage your finances by tracking income, expenses and goals. Use the different tabs to add new transactions, review your balance sheet and update your profile or settings.
+This web application helps you manage your finances by tracking income, expenses and goals. Use the different tabs to add new transactions, review your balance sheet and update your profile or settings. Recurring expenses are entered in the **Expenses** section. One-off outflows should be added as **Goals** so they can be planned for a specific year.
 
 ## Getting Started
 

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -45,7 +45,12 @@ export default function ExpensesGoalsTab() {
         return { ...e, [field]: raw }
       }
       if (field === 'paymentsPerYear') {
-        return { ...e, paymentsPerYear: Math.max(1, parseInt(raw) || 1) }
+        const ppy = parseInt(raw)
+        if (!ppy || ppy < 1) {
+          alert('One-time outflows should be entered as Goals instead of Expenses')
+          return e
+        }
+        return { ...e, paymentsPerYear: ppy }
       }
       return { ...e, [field]: clamp(parseFloat(raw)) }
     }))
@@ -243,7 +248,7 @@ export default function ExpensesGoalsTab() {
               type="number" min="1" step="1"
               value={e.paymentsPerYear}
               onChange={ev => handleExpenseChange(i, 'paymentsPerYear', ev.target.value)}
-              title="Payments per year"
+              title="Payments per year (use a Goal for one-off outflows)"
             />
             <input
               className="border p-2 rounded-md text-right"


### PR DESCRIPTION
## Summary
- clarify that one-off outflows belong in Goals
- validate Pay/Yr field and warn if users try to set 0
- provide tooltip hint about adding goals for one-time payments

## Testing
- `npx jest --runInBand` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_684336c820cc8323b5b705b7d6d283b2