### PR TITLE
Add liability payment confirmation

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -99,21 +99,36 @@ export default function ExpensesGoalsTab() {
     setLiabilitiesList(liabilitiesList.map((l, idx) => {
       if (idx !== i) return l
       let updated = { ...l }
-      if (field === 'name') updated.name = raw
-      else if (['principal', 'interestRate'].includes(field)) {
+
+      if (field === 'name') {
+        updated.name = raw
+      } else if (['principal', 'interestRate'].includes(field)) {
         updated[field] = clamp(parseFloat(raw))
+        updated.paymentConfirmed = false
       } else if (['termYears', 'paymentsPerYear'].includes(field)) {
         updated[field] = Math.max(1, parseInt(raw) || 1)
+        updated.paymentConfirmed = false
       } else if (field === 'payment') {
         updated.payment = clamp(parseFloat(raw))
-        if (!validatePayment(updated)) return l
+        if (!validatePayment(updated)) {
+          updated.paymentConfirmed = false
+          return updated
+        }
+        updated.paymentConfirmed = true
       }
+
       return updated
     }))
   }
   const addLiability = () =>
     setLiabilitiesList([...liabilitiesList, {
-      name: '', principal: 0, interestRate: 0, termYears: 1, paymentsPerYear: 12, payment: 0
+      name: '',
+      principal: 0,
+      interestRate: 0,
+      termYears: 1,
+      paymentsPerYear: 12,
+      payment: 0,
+      paymentConfirmed: false
     }])
   const removeLiability = i =>
     setLiabilitiesList(liabilitiesList.filter((_, idx) => idx !== i))
@@ -176,7 +191,7 @@ export default function ExpensesGoalsTab() {
         }
       })
 
-      return { ...l, computedPayment, pv, schedule }
+      return { ...l, computedPayment, pv, schedule, paymentConfirmed: l.paymentConfirmed }
     })
   }, [liabilitiesList, currentYear])
 
@@ -381,6 +396,8 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={l.payment}
               onChange={ev => handleLiabilityChange(i, 'payment', ev.target.value)}
+              disabled={l.paymentConfirmed}
+              title={l.paymentConfirmed ? 'Payment confirmed' : ''}
             />
             <div className="text-right">{l.computedPayment.toFixed(2)}</div>
             <div className="text-right">{l.pv.toFixed(2)}</div>

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -63,7 +63,13 @@ export function FinanceProvider({ children }) {
   // === Liabilities (Loans) state ===
   const [liabilitiesList, setLiabilitiesList] = useState(() => {
     const s = localStorage.getItem('liabilitiesList')
-    return s ? JSON.parse(s) : []
+    if (!s) return []
+    try {
+      const parsed = JSON.parse(s)
+      return parsed.map(l => ({ paymentConfirmed: false, ...l }))
+    } catch {
+      return []
+    }
   })
 
   // === Profile & KYC fields (with lifeExpectancy) ===
@@ -197,7 +203,14 @@ export function FinanceProvider({ children }) {
     if (sG) setGoalsList(JSON.parse(sG))
 
     const sL = localStorage.getItem('liabilitiesList')
-    if (sL) setLiabilitiesList(JSON.parse(sL))
+    if (sL) {
+      try {
+        const parsed = JSON.parse(sL).map(l => ({ paymentConfirmed: false, ...l }))
+        setLiabilitiesList(parsed)
+      } catch {
+        // ignore malformed stored data
+      }
+    }
 
     const me = localStorage.getItem('monthlyExpense')
     if (me) setMonthlyExpense(+me)


### PR DESCRIPTION
## Summary
- keep a paymentConfirmed flag with each liability
- reset confirmation when loan parameters change
- disable payment input after confirming
- load/save liabilities with the new flag

## Testing
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6843393dc22c8323b74175fea118189a