### PR TITLE
Implement loan NPV calculation

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
-import { calculatePV } from './utils/financeUtils'
+import { calculatePV, calculateLoanNPV } from './utils/financeUtils'
 import { FREQUENCIES } from './constants'
 import {
   PieChart, Pie, Cell, Tooltip,
@@ -163,7 +163,13 @@ export default function ExpensesGoalsTab() {
       const computedPayment = i === 0
         ? l.principal / n
         : (i * l.principal) / (1 - Math.pow(1 + i, -n))
-      const pv = computedPayment * (1 - Math.pow(1 + i, -n)) / i
+      const pv = calculateLoanNPV(
+        l.principal,
+        l.interestRate,
+        l.remainingMonths / 12,
+        l.paymentsPerYear,
+        discountRate
+      ) + l.principal
 
       // Monthly amort schedule aggregated yearly
       let balance = l.principal

--- a/src/__tests__/calculateLoanNPV.test.js
+++ b/src/__tests__/calculateLoanNPV.test.js
@@ -1,0 +1,7 @@
+/* global test, expect */
+import { calculateLoanNPV } from '../utils/financeUtils'
+
+test('calculateLoanNPV matches known mortgage example', () => {
+  const npv = calculateLoanNPV(100000, 5, 30, 12, 4)
+  expect(npv).toBeCloseTo(12443.32, 2)
+})

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -57,3 +57,36 @@ export function calculateAmortizedPayment(principal, annualRate, termYears, paym
   if (r === 0) return principal / n;
   return (r * principal) / (1 - Math.pow(1 + r, -n));
 }
+
+/**
+ * Calculate the net present value of an amortising loan using a discount rate.
+ *
+ * @param {number} principal       - Original or remaining loan balance.
+ * @param {number} annualRate      - Loan interest rate (percent).
+ * @param {number} termYears       - Years until the loan is repaid.
+ * @param {number} paymentsPerYear - Number of payments each year.
+ * @param {number} discountRate    - Discount rate to value the cash flows (percent).
+ * @returns {number} Net present value of the loan.
+ */
+export function calculateLoanNPV(
+  principal,
+  annualRate,
+  termYears,
+  paymentsPerYear,
+  discountRate
+) {
+  const payment = calculateAmortizedPayment(
+    principal,
+    annualRate,
+    termYears,
+    paymentsPerYear
+  );
+  const n = termYears * paymentsPerYear;
+  const d = discountRate / 100 / paymentsPerYear;
+
+  const pvPayments = d === 0
+    ? payment * n
+    : payment * (1 - Math.pow(1 + d, -n)) / d;
+
+  return pvPayments - principal;
+}


### PR DESCRIPTION
## Summary
- add `calculateLoanNPV` utility
- use new loan function in `ExpensesGoalsTab`
- test `calculateLoanNPV` against mortgage example

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68433bb0965883239bf434e82df70a61