### PR TITLE
Implement loan strategy advisor

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -4,6 +4,7 @@ import React, { useMemo, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
 import { calculatePV } from './utils/financeUtils'
 import { FREQUENCIES } from './constants'
+import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend
@@ -182,6 +183,11 @@ export default function ExpensesGoalsTab() {
 
   const totalLiabilitiesPV = liabilityDetails.reduce((s, l) => s + l.pv, 0)
   const totalRequired = pvExpensesLife + pvGoals + totalLiabilitiesPV
+
+  const loanStrategies = useMemo(
+    () => suggestLoanStrategies(liabilityDetails),
+    [liabilityDetails]
+  )
 
   // --- 5) PV Summary data ---
   const pvSummaryData = [
@@ -457,6 +463,28 @@ export default function ExpensesGoalsTab() {
           </div>
         ))}
       </section>
+
+      {loanStrategies.length > 0 && (
+        <div className="bg-white rounded-xl shadow p-4">
+          <h3 className="text-lg font-bold text-amber-700 mb-2">Loan Advisor</h3>
+          <ul className="list-disc pl-5 text-sm space-y-1">
+            {loanStrategies.map((s, i) => (
+              <li key={i}>
+                Pay <strong>{s.name}</strong> early to save&nbsp;
+                <span className="text-amber-700 font-semibold">
+                  {s.interestSaved.toLocaleString(settings.locale, {
+                    style: 'currency',
+                    currency: settings.currency,
+                    maximumFractionDigits: 0
+                  })}
+                </span>
+                {s.paymentsSaved > 0 && ` and cut ${s.paymentsSaved} payments`}
+                .
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {/* Export */}
       <div className="text-right">

--- a/src/__tests__/suggestLoanStrategies.test.js
+++ b/src/__tests__/suggestLoanStrategies.test.js
@@ -1,0 +1,18 @@
+/* global test, expect */
+import suggestLoanStrategies from '../utils/suggestLoanStrategies'
+
+const sampleLoans = [
+  { name: 'Low',  principal: 1000, interestRate: 5,  termYears: 1, paymentsPerYear: 12 },
+  { name: 'High', principal: 1000, interestRate: 10, termYears: 1, paymentsPerYear: 12 }
+]
+
+test('loans ranked by potential interest savings', () => {
+  const result = suggestLoanStrategies(sampleLoans)
+  expect(result[0].name).toBe('High')
+  expect(result[1].name).toBe('Low')
+  expect(result[0].interestSaved).toBeGreaterThan(result[1].interestSaved)
+})
+
+test('handles empty input', () => {
+  expect(suggestLoanStrategies([])).toEqual([])
+})

--- a/src/utils/suggestLoanStrategies.js
+++ b/src/utils/suggestLoanStrategies.js
@@ -1,0 +1,77 @@
+/**
+ * src/utils/suggestLoanStrategies.js
+ *
+ * Given a list of loan liabilities, rank them by the interest savings
+ * achieved when making a 10% extra payment each period. This helps surface
+ * which loans benefit the most from accelerated repayment.
+ */
+
+import { calculateAmortizedPayment } from './financeUtils'
+
+/**
+ * Simulate loan amortisation with a constant payment.
+ * Returns total interest paid and number of payments.
+ */
+function simulateLoan(principal, rate, termYears, paymentsPerYear, payment) {
+  const r = rate / 100 / paymentsPerYear
+  const n = termYears * paymentsPerYear
+  let balance = principal
+  let interestSum = 0
+  let count = 0
+  while (balance > 0 && count < n * 2) {
+    const interest = balance * r
+    interestSum += interest
+    const principalPaid = payment - interest
+    balance -= principalPaid
+    count += 1
+    if (count > n * 2) break
+  }
+  return { interest: interestSum, payments: count }
+}
+
+/**
+ * Rank loans by potential interest saved when paying 10% extra each period.
+ *
+ * @param {Array} loans - Array of liability objects.
+ * @returns {Array} Sorted list with name, interestSaved and paymentsSaved.
+ */
+export default function suggestLoanStrategies(loans = []) {
+  if (!Array.isArray(loans) || loans.length === 0) return []
+
+  return loans
+    .map((loan) => {
+      const payment =
+        loan.computedPayment ??
+        loan.payment ??
+        calculateAmortizedPayment(
+          loan.principal,
+          loan.interestRate,
+          loan.termYears,
+          loan.paymentsPerYear
+        )
+
+      const base = simulateLoan(
+        loan.principal,
+        loan.interestRate,
+        loan.termYears,
+        loan.paymentsPerYear,
+        payment
+      )
+
+      const extra = simulateLoan(
+        loan.principal,
+        loan.interestRate,
+        loan.termYears,
+        loan.paymentsPerYear,
+        payment * 1.1
+      )
+
+      return {
+        name: loan.name || 'Loan',
+        interestSaved: base.interest - extra.interest,
+        paymentsSaved: base.payments - extra.payments
+      }
+    })
+    .sort((a, b) => b.interestSaved - a.interestSaved)
+}
+


### PR DESCRIPTION
## Summary
- add suggestion logic for prioritising loan repayments
- show ranked loan strategies below KPI cards
- test ranking of loan strategy helper

## Testing
- `npm run lint`
- `npm test -- -i`


------
https://chatgpt.com/codex/tasks/task_e_68433940463c8323be8060cf79c0b72b