### PR TITLE
Improve mobile layout and accessibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ export default function App() {
                 ? 'bg-white shadow text-amber-700'
                 : 'text-slate-500 hover:text-amber-700'
             }`}
+            title={tab}
           >
             {tab}
           </button>

--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -61,7 +61,7 @@ export default function BalanceSheetTab() {
     <div className="space-y-6 p-6">
       <h2 className="text-xl font-semibold text-amber-700">Lifetime Balance Sheet</h2>
 
-      <div className="grid grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <h3 className="text-md font-medium mb-2">Assets</h3>
           {assets.map((item, i) => (
@@ -70,16 +70,23 @@ export default function BalanceSheetTab() {
                 className="border p-2 rounded-md w-1/2"
                 value={item.name}
                 onChange={e => updateItem(setAssets, assets, i, 'name', e.target.value)}
+                title="Asset name"
               />
               <input
                 type="number"
                 className="border p-2 rounded-md w-1/2"
                 value={item.amount}
                 onChange={e => updateItem(setAssets, assets, i, 'amount', e.target.value)}
+                title="Asset amount"
               />
             </div>
           ))}
-          <button onClick={addAsset} className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700">
+          <button
+            onClick={addAsset}
+            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700"
+            aria-label="Add asset"
+            title="Add asset"
+          >
             + Add Asset
           </button>
         </div>
@@ -92,16 +99,23 @@ export default function BalanceSheetTab() {
                 className="border p-2 rounded-md w-1/2"
                 value={item.name}
                 onChange={e => updateItem(setLiabilities, liabilities, i, 'name', e.target.value)}
+                title="Liability name"
               />
               <input
                 type="number"
                 className="border p-2 rounded-md w-1/2"
                 value={item.amount}
                 onChange={e => updateItem(setLiabilities, liabilities, i, 'amount', e.target.value)}
+                title="Liability amount"
               />
             </div>
           ))}
-          <button onClick={addLiability} className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700">
+          <button
+            onClick={addLiability}
+            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700"
+            aria-label="Add liability"
+            title="Add liability"
+          >
             + Add Liability
           </button>
         </div>
@@ -111,7 +125,7 @@ export default function BalanceSheetTab() {
         Net Worth: <span className="text-2xl font-bold text-amber-700">KES {netWorth.toLocaleString()}</span>
       </div>
 
-      <div className="grid grid-cols-2 gap-6 mt-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
         <div className="bg-white p-4 rounded-xl shadow-md">
           <h4 className="font-semibold text-slate-700 mb-2">Balance Sheet Overview</h4>
           <ResponsiveContainer width="100%" height={250}>

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -242,6 +242,8 @@ export default function ExpensesGoalsTab() {
   }
 
   const COLORS = ['#fbbf24','#f59e0b','#fcd34d','#fde68a','#eab308']
+  const PRINCIPAL_COLOR = '#34d399'
+  const INTEREST_COLOR  = '#f87171'
 
   return (
     <div className="space-y-8 p-6">
@@ -249,7 +251,7 @@ export default function ExpensesGoalsTab() {
       {/* Expenses CRUD */}
       <section>
         <h2 className="text-2xl font-bold text-amber-700 mb-2">Expenses</h2>
-        <div className="grid grid-cols-6 gap-2 font-semibold text-gray-700 mb-1">
+        <div className="grid grid-cols-1 sm:grid-cols-6 gap-2 font-semibold text-gray-700 mb-1">
           <div>Name</div>
           <div className="text-right">Amt ({settings.currency})</div>
           <div>Pay/Yr</div>
@@ -257,13 +259,17 @@ export default function ExpensesGoalsTab() {
           <div>Category</div>
           <div></div>
         </div>
+        {expensesList.length === 0 && (
+          <p className="italic text-slate-500 col-span-full mb-2">No expenses added</p>
+        )}
         {expensesList.map((e, i) => (
-          <div key={i} className="grid grid-cols-6 gap-2 items-center mb-1">
+          <div key={i} className="grid grid-cols-1 sm:grid-cols-6 gap-2 items-center mb-1">
             <input
               className="border p-2 rounded-md"
               placeholder="Rent"
               value={e.name}
               onChange={ev => handleExpenseChange(i, 'name', ev.target.value)}
+              title="Expense name"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -271,6 +277,7 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={e.amount}
               onChange={ev => handleExpenseChange(i, 'amount', ev.target.value)}
+              title="Expense amount"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -285,11 +292,13 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={e.growth}
               onChange={ev => handleExpenseChange(i, 'growth', ev.target.value)}
+              title="Growth rate"
             />
             <select
               className="border p-2 rounded-md"
               value={e.category}
               onChange={ev => handleExpenseChange(i, 'category', ev.target.value)}
+              title="Expense category"
             >
               <option>Fixed</option>
               <option>Discretionary</option>
@@ -305,25 +314,33 @@ export default function ExpensesGoalsTab() {
         <button
           onClick={addExpense}
           className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
-        >+ Add Expense</button>
+          aria-label="Add expense"
+          title="Add expense"
+        >
+          + Add Expense
+        </button>
       </section>
 
       {/* Goals CRUD */}
       <section>
         <h2 className="text-2xl font-bold text-amber-700 mb-2">Goals</h2>
-        <div className="grid grid-cols-4 gap-2 font-semibold text-gray-700 mb-1">
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-2 font-semibold text-gray-700 mb-1">
           <div>Name</div>
           <div className="text-right">Amt ({settings.currency})</div>
           <div className="text-right">Target Yr</div>
           <div></div>
         </div>
+        {goalsList.length === 0 && (
+          <p className="italic text-slate-500 col-span-full mb-2">No goals added</p>
+        )}
         {goalsList.map((g, i) => (
-          <div key={i} className="grid grid-cols-4 gap-2 items-center mb-1">
+          <div key={i} className="grid grid-cols-1 sm:grid-cols-4 gap-2 items-center mb-1">
             <input
               className="border p-2 rounded-md"
               placeholder="Vacation"
               value={g.name}
               onChange={ev => handleGoalChange(i, 'name', ev.target.value)}
+              title="Goal name"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -331,6 +348,7 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={g.amount}
               onChange={ev => handleGoalChange(i, 'amount', ev.target.value)}
+              title="Goal amount"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -338,6 +356,7 @@ export default function ExpensesGoalsTab() {
               placeholder={String(currentYear)}
               value={g.targetYear}
               onChange={ev => handleGoalChange(i, 'targetYear', ev.target.value)}
+              title="Target year"
             />
             <button
               onClick={() => removeGoal(i)}
@@ -349,13 +368,17 @@ export default function ExpensesGoalsTab() {
         <button
           onClick={addGoal}
           className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
-        >+ Add Goal</button>
+          aria-label="Add goal"
+          title="Add goal"
+        >
+          + Add Goal
+        </button>
       </section>
 
       {/* Liabilities CRUD */}
       <section>
         <h2 className="text-2xl font-bold text-amber-700 mb-2">Liabilities (Loans)</h2>
-        <div className="grid grid-cols-10 gap-2 font-semibold text-gray-700 mb-1">
+        <div className="grid grid-cols-1 sm:grid-cols-10 gap-2 font-semibold text-gray-700 mb-1">
           <div>Name</div>
           <div className="text-right">Principal</div>
           <div className="text-right">Interest %</div>
@@ -367,13 +390,17 @@ export default function ExpensesGoalsTab() {
           <div className="text-right">PV</div>
           <div></div>
         </div>
+        {liabilityDetails.length === 0 && (
+          <p className="italic text-slate-500 col-span-full mb-2">No loans added</p>
+        )}
         {liabilityDetails.map((l, i) => (
-          <div key={i} className="grid grid-cols-10 gap-2 items-center mb-1">
+          <div key={i} className="grid grid-cols-1 sm:grid-cols-10 gap-2 items-center mb-1">
             <input
               className="border p-2 rounded-md"
               placeholder="Car Loan"
               value={l.name}
               onChange={ev => handleLiabilityChange(i, 'name', ev.target.value)}
+              title="Loan name"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -381,6 +408,7 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={l.principal}
               onChange={ev => handleLiabilityChange(i, 'principal', ev.target.value)}
+              title="Principal"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -388,6 +416,7 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={l.interestRate}
               onChange={ev => handleLiabilityChange(i, 'interestRate', ev.target.value)}
+              title="Interest rate"
             />
             <input
               className="border p-2 rounded-md text-right"
@@ -395,17 +424,20 @@ export default function ExpensesGoalsTab() {
               placeholder="1"
               value={l.termYears}
               onChange={ev => handleLiabilityChange(i, 'termYears', ev.target.value)}
+              title="Term years"
             />
             <input
               className="border p-2 rounded-md text-right"
               type="number" min="1" step="1"
               value={l.remainingMonths}
               onChange={ev => handleLiabilityChange(i, 'remainingMonths', ev.target.value)}
+              title="Remaining months"
             />
           <select
             className="border p-2 rounded-md"
             value={l.paymentsPerYear}
             onChange={ev => handleLiabilityChange(i, 'paymentsPerYear', ev.target.value)}
+            title="Payments per year"
           >
             {FREQUENCIES.map(f => (
               <option key={f} value={payMap[f]}>{f}</option>
@@ -417,6 +449,7 @@ export default function ExpensesGoalsTab() {
               placeholder="0"
               value={l.payment}
               onChange={ev => handleLiabilityChange(i, 'payment', ev.target.value)}
+              title="Actual payment"
             />
             <div className="text-right">{l.computedPayment.toFixed(2)}</div>
             <div className="text-right">{l.pv.toFixed(2)}</div>
@@ -430,7 +463,11 @@ export default function ExpensesGoalsTab() {
         <button
           onClick={addLiability}
           className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
-        >+ Add Liability</button>
+          aria-label="Add liability"
+          title="Add liability"
+        >
+          + Add Liability
+        </button>
       </section>
 
       {/* PV Summary Bar Chart */}
@@ -467,8 +504,8 @@ export default function ExpensesGoalsTab() {
                   v.toLocaleString(settings.locale,{style:'currency',currency:settings.currency})
                 }/>
                 <Legend verticalAlign="bottom" />
-                <Bar dataKey="principalPaid" stackId="a" name="Principal" fill={COLORS[2]} />
-                <Bar dataKey="interestPaid"  stackId="a" name="Interest"  fill={COLORS[3]} />
+                <Bar dataKey="principalPaid" stackId="a" name="Principal" fill={PRINCIPAL_COLOR} />
+                <Bar dataKey="interestPaid"  stackId="a" name="Interest"  fill={INTEREST_COLOR} />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -521,7 +558,11 @@ export default function ExpensesGoalsTab() {
         <button
           onClick={exportJSON}
           className="mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50"
-        >📁 Export to JSON</button>
+          aria-label="Export to JSON"
+          title="Export to JSON"
+        >
+          📁 Export to JSON
+        </button>
       </div>
     </div>
   )

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -247,6 +247,7 @@ export default function IncomeTab() {
                 value={src.name}
                 onChange={e => onFieldChange(i, 'name', e.target.value)}
                 required
+                title="Source name"
               />
 
               <label className="block text-sm font-medium mt-2">Type</label>
@@ -255,6 +256,7 @@ export default function IncomeTab() {
                 value={src.type}
                 onChange={e => onFieldChange(i, 'type', e.target.value)}
                 aria-label="Income type"
+                title="Income type"
               >
                 <option>Employment</option>
                 <option>Business</option>
@@ -324,7 +326,10 @@ export default function IncomeTab() {
           onClick={addIncome}
           className="mt-4 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
           aria-label="Add income source"
-        >➕ Add Income</button>
+          title="Add income source"
+        >
+          ➕ Add Income
+        </button>
       </section>
 
       {/* Assumptions */}
@@ -337,6 +342,7 @@ export default function IncomeTab() {
             value={startYear}
             onChange={e => setStartYear(+e.target.value)}
             min={1900} max={2100}
+            title="Start year"
           />
 
           <label className="block text-sm font-medium mt-4">Discount Rate (%)</label>
@@ -346,6 +352,7 @@ export default function IncomeTab() {
             value={discountRate}
             onChange={e => setDiscountRate(+e.target.value)}
             min={0} max={100} step={0.1}
+            title="Discount rate"
           />
 
           <label className="block text-sm font-medium mt-4">Projection Years</label>
@@ -355,6 +362,7 @@ export default function IncomeTab() {
             value={years}
             onChange={e => setYears(+e.target.value)}
             min={1}
+            title="Projection years"
           />
 
           <label className="block text-sm font-medium mt-4">Chart View</label>
@@ -397,6 +405,7 @@ export default function IncomeTab() {
               className="mr-2"
               checked={includeGoalsPV}
               onChange={e => setIncludeGoalsPV(e.target.checked)}
+              aria-label="Include goals present value"
             />
             Include Goals (PV)
           </label>
@@ -406,6 +415,7 @@ export default function IncomeTab() {
               className="mr-2"
               checked={includeLiabilitiesNPV}
               onChange={e => setIncludeLiabilitiesNPV(e.target.checked)}
+              aria-label="Include liabilities NPV"
             />
             Include Liabilities (NPV)
           </label>
@@ -514,18 +524,24 @@ export default function IncomeTab() {
         <button
           onClick={exportJSON}
           className="bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          aria-label="Export income to JSON"
+          title="Export income to JSON"
         >
           📁 Export Income to JSON
         </button>
         <button
           onClick={exportCSV}
           className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          aria-label="Export CSV"
+          title="Export CSV"
         >
           📊 Export CSV
         </button>
         <button
           onClick={triggerPrint}
           className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          aria-label="Print"
+          title="Print"
         >
           🖨️ Print
         </button>

--- a/src/ProfileTab.jsx
+++ b/src/ProfileTab.jsx
@@ -63,6 +63,7 @@ export default function ProfileTab() {
                   value={form[field]}
                   onChange={e => handleChange(field, e.target.value)}
                   className="w-full border rounded-md p-2"
+                  title={label}
                 >
                   {options.map(o => (
                     <option key={o} value={o}>
@@ -81,6 +82,7 @@ export default function ProfileTab() {
                     )
                   }
                   className="w-full border rounded-md p-2"
+                  title={label}
                 />
               )}
             </label>
@@ -103,6 +105,7 @@ export default function ProfileTab() {
                 value={form[field]}
                 onChange={e => handleChange(field, e.target.value)}
                 className="w-full border rounded-md p-2"
+                title={label}
               />
             </label>
           ))}
@@ -118,6 +121,7 @@ export default function ProfileTab() {
                 value={form[field]}
                 onChange={e => handleChange(field, parseFloat(e.target.value) || 0)}
                 className="w-full border rounded-md p-2"
+                title={label}
               />
             </label>
           ))}
@@ -129,6 +133,7 @@ export default function ProfileTab() {
               onChange={e => handleChange('sourceOfFunds', e.target.value)}
               className="w-full border rounded-md p-2"
               rows={3}
+              title="Source of funds"
             />
           </label>
         </div>
@@ -150,6 +155,7 @@ export default function ProfileTab() {
                 value={form[field]}
                 onChange={e => handleChange(field, e.target.value)}
                 className="w-full border rounded-md p-2"
+                title={label}
               >
                 {options.map(o => (
                   <option key={o} value={o}>

--- a/src/SettingsTab.jsx
+++ b/src/SettingsTab.jsx
@@ -31,6 +31,7 @@ export default function SettingsTab() {
             value={form.inflationRate}
             onChange={e => handleChange('inflationRate', parseFloat(e.target.value) || 0)}
             className="w-full border rounded-md p-2"
+            title="Inflation rate"
           />
         </label>
 
@@ -42,6 +43,7 @@ export default function SettingsTab() {
             value={form.expectedReturn}
             onChange={e => handleChange('expectedReturn', parseFloat(e.target.value) || 0)}
             className="w-full border rounded-md p-2"
+            title="Expected annual return"
           />
         </label>
 
@@ -52,6 +54,7 @@ export default function SettingsTab() {
             value={form.currency}
             onChange={e => handleChange('currency', e.target.value)}
             className="w-full border rounded-md p-2"
+            title="Default currency"
           >
             <option value="KES">KES</option>
             <option value="USD">USD</option>
@@ -66,6 +69,7 @@ export default function SettingsTab() {
             value={form.locale}
             onChange={e => handleChange('locale', e.target.value)}
             className="w-full border rounded-md p-2"
+            title="Locale"
           >
             <option value="en-KE">English (Kenya)</option>
             <option value="en-US">English (US)</option>
@@ -82,6 +86,7 @@ export default function SettingsTab() {
             onChange={e => handleChange('apiEndpoint', e.target.value)}
             placeholder="https://api.your-backend.com/submit"
             className="w-full border rounded-md p-2"
+            title="API endpoint"
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary
- use responsive grid classes for small screens
- add empty-list placeholders in Expenses & Goals tab
- improve amortization chart colors
- add titles and aria labels to inputs and buttons

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6843444dc3a48323b94e0851dceb03a4