### PR TITLE
Add tests for repayment utilities and frequency mapping

### DIFF
--- a/src/__tests__/frequencyConversion.test.js
+++ b/src/__tests__/frequencyConversion.test.js
@@ -1,0 +1,22 @@
+import { frequencyToPayments, calculatePV } from '../utils/financeUtils'
+
+/* global test, expect */
+
+test('frequencyToPayments handles known strings', () => {
+  expect(frequencyToPayments('Monthly')).toBe(12)
+  expect(frequencyToPayments('Quarterly')).toBe(4)
+  expect(frequencyToPayments('Annually')).toBe(1)
+})
+
+test('frequencyToPayments handles numeric and invalid values', () => {
+  expect(frequencyToPayments(24)).toBe(24)
+  expect(frequencyToPayments(0)).toBe(0)
+  expect(frequencyToPayments(-3)).toBe(0)
+  expect(frequencyToPayments('Weekly')).toBe(0)
+  expect(frequencyToPayments()).toBe(0)
+})
+
+test('calculatePV returns zero for unknown frequency', () => {
+  const pv = calculatePV(100, frequencyToPayments('Unknown'), 0, 5, 5)
+  expect(pv).toBe(0)
+})

--- a/src/__tests__/repaymentUtils.test.js
+++ b/src/__tests__/repaymentUtils.test.js
@@ -1,0 +1,25 @@
+import { calculateLumpSumPV, calculateAmortizedPayment } from '../utils/financeUtils'
+
+/* global test, expect */
+
+test('calculateLumpSumPV discounts future cash flow', () => {
+  const pv = calculateLumpSumPV(1000, 10, 2)
+  expect(pv).toBeCloseTo(1000 / Math.pow(1.1, 2))
+})
+
+test('calculateLumpSumPV handles zero rate', () => {
+  expect(calculateLumpSumPV(500, 0, 3)).toBe(500)
+})
+
+test('calculateAmortizedPayment handles zero interest', () => {
+  const pay = calculateAmortizedPayment(1200, 0, 1, 12)
+  expect(pay).toBeCloseTo(100)
+})
+
+test('calculateAmortizedPayment with interest', () => {
+  const pay = calculateAmortizedPayment(10000, 6, 2, 12)
+  const r = 0.06 / 12
+  const n = 24
+  const expected = (r * 10000) / (1 - Math.pow(1 + r, -n))
+  expect(pay).toBeCloseTo(expected)
+})

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -28,6 +28,19 @@ export function calculatePV(amount, frequency, growthRate, discountRate, periods
   return A * (1 - Math.pow((1 + g) / (1 + d), periods)) / (d - g);
 }
 
+/**
+ * Convert a frequency value to payments per year.
+ * Accepts recognized strings or numeric values.
+ *
+ * @param {string|number} freq - Frequency label or numeric payments per year.
+ * @returns {number} Payments per year (0 if invalid).
+ */
+export function frequencyToPayments(freq) {
+  if (typeof freq === 'number') return freq > 0 ? freq : 0;
+  const map = { Monthly: 12, Quarterly: 4, Annually: 1 };
+  return map[freq] ?? 0;
+}
+
 
 /**
  * Calculate present value of a single future amount.


### PR DESCRIPTION
## Summary
- add `frequencyToPayments` utility for mapping frequencies to payments per year
- test edge cases for frequency conversion
- test repayment utilities (`calculateLumpSumPV` and `calculateAmortizedPayment`)

## Testing
- `npx jest --runInBand`
- `npx jest --runInBand --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68433940d6288323a2797d5af4a9d16b