### PR TITLE
Use shared helper for frequency conversions

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
-import { calculatePV, calculateLoanNPV } from './utils/financeUtils'
+import { calculatePV, calculateLoanNPV, frequencyToPayments } from './utils/financeUtils'
 import { FREQUENCIES } from './constants'
 import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import {
@@ -32,7 +32,6 @@ export default function ExpensesGoalsTab() {
     settings
   } = useFinance()
 
-  const payMap = { Monthly: 12, Quarterly: 4, Annually: 1 }
 
   // --- Helpers ---
   const clamp = (v, min = 0) => isNaN(v) || v < min ? min : v
@@ -440,7 +439,7 @@ export default function ExpensesGoalsTab() {
             title="Payments per year"
           >
             {FREQUENCIES.map(f => (
-              <option key={f} value={payMap[f]}>{f}</option>
+              <option key={f} value={frequencyToPayments(f)}>{f}</option>
             ))}
           </select>
             <input

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -1,10 +1,9 @@
 // src/FinanceContext.jsx
 
 import React, { createContext, useContext, useState, useEffect } from 'react'
-import { calculatePV } from './utils/financeUtils'
+import { calculatePV, frequencyToPayments } from './utils/financeUtils'
 
 const FinanceContext = createContext()
-const payMap = { Monthly: 12, Quarterly: 4, Annually: 1 }
 
 export function FinanceProvider({ children }) {
   // === Core financial state ===
@@ -46,7 +45,7 @@ export function FinanceProvider({ children }) {
       const parsed = JSON.parse(s)
       return parsed.map(exp => {
         if (typeof exp.paymentsPerYear === 'number') return exp
-        const ppy = payMap[exp.frequency] ?? 1
+        const ppy = frequencyToPayments(exp.frequency) || 1
         const { frequency: _unused, ...rest } = exp
         return { ...rest, paymentsPerYear: ppy }
       })
@@ -183,12 +182,14 @@ export function FinanceProvider({ children }) {
     if (sExp) {
       try {
         const parsed = JSON.parse(sExp)
-        setExpensesList(parsed.map(exp => {
-          if (typeof exp.paymentsPerYear === 'number') return exp
-          const ppy = payMap[exp.frequency] ?? 1
-          const { frequency: _unused, ...rest } = exp
-          return { ...rest, paymentsPerYear: ppy }
-        }))
+        setExpensesList(
+          parsed.map(exp => {
+            if (typeof exp.paymentsPerYear === 'number') return exp
+            const ppy = frequencyToPayments(exp.frequency) || 1
+            const { frequency: _unused, ...rest } = exp
+            return { ...rest, paymentsPerYear: ppy }
+          })
+        )
       } catch {
         // ignore malformed stored data
       }


### PR DESCRIPTION
## Summary
- remove inline payMap constants
- derive payments per year using `frequencyToPayments`

## Testing
- `npx jest --runInBand`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684347ff6a3c8323abf2b561f959b218