### PR TITLE
Fix useMemo deps for liabilityDetails

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -201,7 +201,7 @@ export default function ExpensesGoalsTab() {
 
       return { ...l, computedPayment, pv, schedule }
     })
-  }, [liabilitiesList, currentYear])
+  }, [liabilitiesList, currentYear, discountRate])
 
   const totalLiabilitiesPV = liabilityDetails.reduce((s, l) => s + l.pv, 0)
   const totalRequired = pvExpensesLife + pvGoals + totalLiabilitiesPV


### PR DESCRIPTION
## Summary
- fix the `liabilityDetails` dependencies to include `discountRate`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843514e8f188323b3b1933cc1a4393c