### PR TITLE
Add spending advice logic

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -52,12 +52,16 @@ export default function ExpensesGoalsTab() {
         }
         return { ...e, paymentsPerYear: ppy }
       }
+      if (field === 'priority') {
+        const val = parseInt(raw)
+        return { ...e, priority: val >= 1 && val <= 3 ? val : 2 }
+      }
       return { ...e, [field]: clamp(parseFloat(raw)) }
     }))
   }
   const addExpense = () => {
     setExpensesList([...expensesList, {
-      name: '', amount: 0, paymentsPerYear: 12, growth: 0, category: 'Fixed'
+      name: '', amount: 0, paymentsPerYear: 12, growth: 0, category: 'Fixed', priority: 2
     }])
   }
   const removeExpense = i =>
@@ -250,19 +254,20 @@ export default function ExpensesGoalsTab() {
       {/* Expenses CRUD */}
       <section>
         <h2 className="text-2xl font-bold text-amber-700 mb-2">Expenses</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-6 gap-2 font-semibold text-gray-700 mb-1">
+        <div className="grid grid-cols-1 sm:grid-cols-7 gap-2 font-semibold text-gray-700 mb-1">
           <div>Name</div>
           <div className="text-right">Amt ({settings.currency})</div>
           <div>Pay/Yr</div>
           <div className="text-right">Growth %</div>
           <div>Category</div>
+          <div>Priority</div>
           <div></div>
         </div>
         {expensesList.length === 0 && (
           <p className="italic text-slate-500 col-span-full mb-2">No expenses added</p>
         )}
         {expensesList.map((e, i) => (
-          <div key={i} className="grid grid-cols-1 sm:grid-cols-6 gap-2 items-center mb-1">
+          <div key={i} className="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mb-1">
             <input
               className="border p-2 rounded-md"
               placeholder="Rent"
@@ -302,6 +307,16 @@ export default function ExpensesGoalsTab() {
               <option>Fixed</option>
               <option>Discretionary</option>
               <option>Other</option>
+            </select>
+            <select
+              className="border p-2 rounded-md"
+              value={e.priority}
+              onChange={ev => handleExpenseChange(i, 'priority', ev.target.value)}
+              title="Expense priority"
+            >
+              <option value={1}>High</option>
+              <option value={2}>Medium</option>
+              <option value={3}>Low</option>
             </select>
             <button
               onClick={() => removeExpense(i)}

--- a/src/SettingsTab.jsx
+++ b/src/SettingsTab.jsx
@@ -77,6 +77,25 @@ export default function SettingsTab() {
           </select>
         </label>
 
+        {/* Discretionary Warning Threshold */}
+        <label className="block">
+          <span className="text-sm text-slate-600">Discretionary Warning Threshold (%)</span>
+          <input
+            type="number"
+            min={0}
+            max={100}
+            value={form.discretionaryCutThreshold}
+            onChange={e =>
+              handleChange(
+                'discretionaryCutThreshold',
+                Math.min(100, Math.max(0, parseFloat(e.target.value) || 0))
+              )
+            }
+            className="w-full border rounded-md p-2"
+            title="Threshold as % of monthly expenses"
+          />
+        </label>
+
         {/* API Endpoint */}
         <label className="block md:col-span-2">
           <span className="text-sm text-slate-600">API Endpoint (for exports)</span>

--- a/src/__tests__/calcDiscretionaryAdvice.test.js
+++ b/src/__tests__/calcDiscretionaryAdvice.test.js
@@ -1,0 +1,19 @@
+/* global test, expect */
+import calcDiscretionaryAdvice from '../utils/calcDiscretionaryAdvice'
+
+const expenses = [
+  { name: 'Streaming', amount: 10, paymentsPerYear: 12, priority: 3 },
+  { name: 'Coffee', amount: 70, paymentsPerYear: 12, priority: 3 },
+  { name: 'Gym', amount: 50, paymentsPerYear: 12, priority: 2 }
+]
+
+test('suggests low priority cuts sorted by impact', () => {
+  const advice = calcDiscretionaryAdvice(expenses, 1000, 100, 20)
+  expect(advice.length).toBe(2)
+  expect(advice[0].name).toBe('Coffee')
+  expect(advice[1].name).toBe('Streaming')
+})
+
+test('returns empty when surplus above threshold', () => {
+  expect(calcDiscretionaryAdvice(expenses, 1000, 300, 20)).toEqual([])
+})

--- a/src/utils/calcDiscretionaryAdvice.js
+++ b/src/utils/calcDiscretionaryAdvice.js
@@ -1,0 +1,22 @@
+export default function calcDiscretionaryAdvice(expenses = [], monthlyExpense = 0, monthlySurplus = 0, thresholdPercent = 0) {
+  if (!Array.isArray(expenses) || expenses.length === 0) return []
+  const thresholdAmt = (thresholdPercent / 100) * monthlyExpense
+  const deficit = thresholdAmt - monthlySurplus
+  if (deficit <= 0) return []
+  const lowPriority = expenses
+    .filter(e => e.priority === 3)
+    .map(e => ({
+      name: e.name || 'Expense',
+      monthly: (parseFloat(e.amount) || 0) * (e.paymentsPerYear || 0) / 12
+    }))
+    .sort((a, b) => b.monthly - a.monthly)
+  const suggestions = []
+  let saved = 0
+  for (const item of lowPriority) {
+    if (saved >= deficit) break
+    suggestions.push({ name: item.name, amount: item.monthly })
+    saved += item.monthly
+  }
+  return suggestions
+}
+


### PR DESCRIPTION
## Summary
- track expense priority and persist it
- compute monthly surplus and persist
- let users choose a discretionary warning threshold
- offer spending cut advice when surplus is low
- test helper for trimming discretionary expenses

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684353a0dbac8323a8116fd14eaab5f7