### PR TITLE
Add survival metric tests

### DIFF
--- a/src/__tests__/calcDiscretionaryAdvice.test.js
+++ b/src/__tests__/calcDiscretionaryAdvice.test.js
@@ -17,3 +17,24 @@ test('suggests low priority cuts sorted by impact', () => {
 test('returns empty when surplus above threshold', () => {
   expect(calcDiscretionaryAdvice(expenses, 1000, 300, 20)).toEqual([])
 })
+
+test('suggestions accumulate until threshold met', () => {
+  const moreExpenses = [
+    ...expenses,
+    { name: 'Snacks', amount: 50, paymentsPerYear: 12, priority: 3 }
+  ]
+  // Surplus 50, threshold 20% of 1000 = 200 -> deficit 150
+  const advice = calcDiscretionaryAdvice(moreExpenses, 1000, 50, 20)
+  expect(advice.map(a => a.name)).toEqual(['Coffee', 'Snacks', 'Streaming'])
+})
+
+test('stops once savings exceed deficit', () => {
+  const moreExpenses = [
+    { name: 'Takeout', amount: 100, paymentsPerYear: 12, priority: 3 },
+    ...expenses
+  ]
+  // Surplus 150, threshold 20% = 200 -> deficit 50, only highest item needed
+  const advice = calcDiscretionaryAdvice(moreExpenses, 1000, 150, 20)
+  expect(advice).toHaveLength(1)
+  expect(advice[0].name).toBe('Takeout')
+})

--- a/src/__tests__/survivalMetrics.test.js
+++ b/src/__tests__/survivalMetrics.test.js
@@ -1,0 +1,24 @@
+/* global test, expect */
+import { calculateNominalSurvival, calculatePVSurvival } from '../utils/survivalMetrics'
+
+// Example inputs
+const totalPV = 120000
+const discount = 6
+const years = 10
+const monthlyExpense = 1000
+
+test('nominal survival uses annuity factor', () => {
+  const months = calculateNominalSurvival(totalPV, discount, years, monthlyExpense)
+  expect(months).toBe(1)
+})
+
+test('pv survival uses exponential formula', () => {
+  const months = calculatePVSurvival(totalPV, discount, monthlyExpense, years)
+  expect(months).toBe(183)
+})
+
+test('pv survival caps at total period when ratio >= 1', () => {
+  const highPV = 300000
+  const months = calculatePVSurvival(highPV, discount, monthlyExpense, years)
+  expect(months).toBe(years * 12)
+})

--- a/src/utils/survivalMetrics.js
+++ b/src/utils/survivalMetrics.js
@@ -1,0 +1,17 @@
+export function calculateNominalSurvival(totalIncomePV, discountRate, years, monthlyExpense) {
+  const r = discountRate / 100 / 12
+  const n = years * 12
+  const annuityFactor = r === 0 ? n : (1 - Math.pow(1 + r, -n)) / r
+  const monthlyIncomeEquivalent = annuityFactor > 0 ? totalIncomePV / annuityFactor : 0
+  return monthlyExpense > 0 ? Math.floor(monthlyIncomeEquivalent / monthlyExpense) : 0
+}
+
+export function calculatePVSurvival(totalIncomePV, discountRate, monthlyExpense, years) {
+  if (monthlyExpense <= 0) return 0
+  const r = discountRate / 100 / 12
+  if (r === 0) return Math.floor(totalIncomePV / monthlyExpense)
+  const ratio = (totalIncomePV * r) / monthlyExpense
+  if (ratio >= 1) return years * 12
+  const n = -Math.log(1 - ratio) / Math.log(1 + r)
+  return Math.floor(n)
+}


### PR DESCRIPTION
## Summary
- implement utilities to compute survival months
- test nominal and PV survival calculations
- expand discretionary advice tests for threshold logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68435552bf08832390dae44cf04f7803