### PR TITLE
Handle zero expense survival

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -96,12 +96,12 @@ export default function IncomeTab() {
     () =>
       monthlyExpense > 0
         ? Math.floor(monthlyIncomeEquivalent / monthlyExpense)
-        : 0,
+        : Infinity,
     [monthlyIncomeEquivalent, monthlyExpense]
   );
 
   const pvSurvivalMonths = useMemo(() => {
-    if (monthlyExpense <= 0) return 0;
+    if (monthlyExpense <= 0) return Infinity;
     const r = discountRate / 100 / 12;
     if (r === 0) return Math.floor(totalIncomePV / monthlyExpense);
     const ratio = (totalIncomePV * r) / monthlyExpense;
@@ -142,7 +142,7 @@ export default function IncomeTab() {
     () =>
       monthlyObligations > 0
         ? Math.floor(interruptionPV / monthlyObligations)
-        : 0,
+        : Infinity,
     [interruptionPV, monthlyObligations]
   );
 
@@ -509,11 +509,15 @@ export default function IncomeTab() {
         </p>
         <p className="text-sm mt-2" title="Months covered ignoring discounting">
           Nominal Survival:&nbsp;
-          <strong>{nominalSurvivalMonths}</strong>&nbsp;months
+          <strong>{nominalSurvivalMonths === Infinity ? '∞' : nominalSurvivalMonths}</strong>
+          {nominalSurvivalMonths === Infinity ? '' : '\u00A0months'}
+          {nominalSurvivalMonths === Infinity && ' (No expenses)'}
         </p>
         <p className="text-sm" title="Months covered when discounting each month">
           PV Survival:&nbsp;
-          <strong>{pvSurvivalMonths}</strong>&nbsp;months
+          <strong>{pvSurvivalMonths === Infinity ? '∞' : pvSurvivalMonths}</strong>
+          {pvSurvivalMonths === Infinity ? '' : '\u00A0months'}
+          {pvSurvivalMonths === Infinity && ' (No expenses)'}
         </p>
         {(() => {
           const color =

--- a/src/__tests__/survivalMetrics.test.js
+++ b/src/__tests__/survivalMetrics.test.js
@@ -22,3 +22,8 @@ test('pv survival caps at total period when ratio >= 1', () => {
   const months = calculatePVSurvival(highPV, discount, monthlyExpense, years)
   expect(months).toBe(years * 12)
 })
+
+test('returns Infinity when expenses are zero', () => {
+  expect(calculateNominalSurvival(totalPV, discount, years, 0)).toBe(Infinity)
+  expect(calculatePVSurvival(totalPV, discount, 0, years)).toBe(Infinity)
+})

--- a/src/utils/survivalMetrics.js
+++ b/src/utils/survivalMetrics.js
@@ -3,11 +3,11 @@ export function calculateNominalSurvival(totalIncomePV, discountRate, years, mon
   const n = years * 12
   const annuityFactor = r === 0 ? n : (1 - Math.pow(1 + r, -n)) / r
   const monthlyIncomeEquivalent = annuityFactor > 0 ? totalIncomePV / annuityFactor : 0
-  return monthlyExpense > 0 ? Math.floor(monthlyIncomeEquivalent / monthlyExpense) : 0
+  return monthlyExpense > 0 ? Math.floor(monthlyIncomeEquivalent / monthlyExpense) : Infinity
 }
 
 export function calculatePVSurvival(totalIncomePV, discountRate, monthlyExpense, years) {
-  if (monthlyExpense <= 0) return 0
+  if (monthlyExpense <= 0) return Infinity
   const r = discountRate / 100 / 12
   if (r === 0) return Math.floor(totalIncomePV / monthlyExpense)
   const ratio = (totalIncomePV * r) / monthlyExpense


### PR DESCRIPTION
## Summary
- return `Infinity` from `calculateNominalSurvival` and `calculatePVSurvival` when there are no expenses
- compute `Infinity` months in `IncomeTab` when monthly expenses or obligations are zero
- show ∞ and "No expenses" text in the summary section
- test that survival metrics are infinite for zero expenses

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843590b06148323ba2791a01d37fe3f