### PR TITLE
Add PV obligation survival metric

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -146,6 +146,12 @@ export default function IncomeTab() {
     [interruptionPV, monthlyObligations]
   );
 
+  const pvObligationSurvivalMonths = useMemo(() => {
+    const df = Math.pow(1 + discountRate / 100, 1 / 12);
+    const adjusted = monthlyObligations * df;
+    return adjusted > 0 ? Math.floor(totalIncomePV / adjusted) : Infinity;
+  }, [monthlyObligations, discountRate, totalIncomePV]);
+
   // 3. Build projection data for chart
   const incomeData = useMemo(() => {
     if (chartView === 'monthly') {
@@ -518,6 +524,14 @@ export default function IncomeTab() {
           <strong>{pvSurvivalMonths === Infinity ? '∞' : pvSurvivalMonths}</strong>
           {pvSurvivalMonths === Infinity ? '' : '\u00A0months'}
           {pvSurvivalMonths === Infinity && ' (No expenses)'}
+        </p>
+        <p className="text-sm" title="Months with PV obligations included">
+          PV Survival (Obligations):&nbsp;
+          <strong>
+            {pvObligationSurvivalMonths === Infinity ? '∞' : pvObligationSurvivalMonths}
+          </strong>
+          {pvObligationSurvivalMonths === Infinity ? '' : '\u00A0months'}
+          {pvObligationSurvivalMonths === Infinity && ' (No obligations)'}
         </p>
         {(() => {
           const color =

--- a/src/__tests__/survivalMetrics.test.js
+++ b/src/__tests__/survivalMetrics.test.js
@@ -1,5 +1,9 @@
 /* global test, expect */
-import { calculateNominalSurvival, calculatePVSurvival } from '../utils/survivalMetrics'
+import {
+  calculateNominalSurvival,
+  calculatePVSurvival,
+  calculatePVObligationSurvival
+} from '../utils/survivalMetrics'
 
 // Example inputs
 const totalPV = 120000
@@ -26,4 +30,13 @@ test('pv survival caps at total period when ratio >= 1', () => {
 test('returns Infinity when expenses are zero', () => {
   expect(calculateNominalSurvival(totalPV, discount, years, 0)).toBe(Infinity)
   expect(calculatePVSurvival(totalPV, discount, 0, years)).toBe(Infinity)
+})
+
+test('pv obligation survival uses discounted monthly obligations', () => {
+  const months = calculatePVObligationSurvival(totalPV, discount, monthlyExpense)
+  expect(months).toBe(119)
+})
+
+test('pv obligation survival returns Infinity when obligation is zero', () => {
+  expect(calculatePVObligationSurvival(totalPV, discount, 0)).toBe(Infinity)
 })

--- a/src/utils/survivalMetrics.js
+++ b/src/utils/survivalMetrics.js
@@ -15,3 +15,9 @@ export function calculatePVSurvival(totalIncomePV, discountRate, monthlyExpense,
   const n = -Math.log(1 - ratio) / Math.log(1 + r)
   return Math.floor(n)
 }
+
+export function calculatePVObligationSurvival(totalIncomePV, discountRate, monthlyObligation) {
+  const df = Math.pow(1 + discountRate / 100, 1 / 12)
+  const adjusted = monthlyObligation * df
+  return adjusted > 0 ? Math.floor(totalIncomePV / adjusted) : Infinity
+}


### PR DESCRIPTION
## Summary
- compute PV survival considering optional goals/liabilities in `survivalMetrics`
- test the new PV obligation survival helper
- show PV obligation survival in `IncomeTab`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435a76575083238bf4afebf6917182