### PR TITLE
Add Interruption Months display

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -533,6 +533,12 @@ export default function IncomeTab() {
           {pvObligationSurvivalMonths === Infinity ? '' : '\u00A0months'}
           {pvObligationSurvivalMonths === Infinity && ' (No obligations)'}
         </p>
+        <p className="text-sm" title="Months remaining income covers obligations">
+          Interruption Months:&nbsp;
+          <strong>{_interruptionMonths === Infinity ? '∞' : _interruptionMonths}</strong>
+          {_interruptionMonths === Infinity ? '' : '\u00A0months'}
+          {_interruptionMonths === Infinity && ' (No obligations)'}
+        </p>
         {(() => {
           const color =
             pvSurvivalMonths < 6


### PR DESCRIPTION
## Summary
- show interruption months in the present value summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435b885680832396e44b9d9037fdcb