### PR TITLE
Add AdviceDashboard and new settings

### DIFF
--- a/src/AdviceDashboard.jsx
+++ b/src/AdviceDashboard.jsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { useFinance } from './FinanceContext'
+
+export default function AdviceDashboard({ advice, discretionaryAdvice = [], loanStrategies = [] }) {
+  const { settings } = useFinance()
+  if (!advice) return null
+  const { survival = {}, dti } = advice
+  return (
+    <div className="bg-white rounded-xl shadow p-4 space-y-4">
+      <h3 className="text-lg font-bold text-amber-700">Advice Dashboard</h3>
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div className="space-y-1 text-sm">
+          <p>
+            Nominal Survival:&nbsp;
+            <strong>{survival.nominal === Infinity ? '∞' : survival.nominal}</strong>
+            {survival.nominal !== Infinity && '\u00A0months'}
+          </p>
+          <p>
+            PV Survival:&nbsp;
+            <strong>{survival.pv === Infinity ? '∞' : survival.pv}</strong>
+            {survival.pv !== Infinity && '\u00A0months'}
+          </p>
+          <p>
+            Debt-to-Income Ratio:&nbsp;
+            <strong>{(dti * 100).toFixed(1)}%</strong>
+          </p>
+        </div>
+        {discretionaryAdvice.length > 0 && (
+          <div>
+            <h4 className="font-semibold mb-1">Spending Advice</h4>
+            <ul className="list-disc pl-5 space-y-1">
+              {discretionaryAdvice.map((d, i) => (
+                <li key={i} className="text-sm">
+                  Cut <strong>{d.name}</strong> (~
+                  {d.amount.toLocaleString(settings.locale, {
+                    style: 'currency',
+                    currency: settings.currency,
+                    maximumFractionDigits: 0,
+                  })}
+                  /mo)
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {loanStrategies.length > 0 && (
+          <div>
+            <h4 className="font-semibold mb-1">Loan Strategies</h4>
+            <ul className="list-disc pl-5 space-y-1">
+              {loanStrategies.map((s, i) => (
+                <li key={i} className="text-sm">
+                  Pay <strong>{s.name}</strong> early to save{' '}
+                  {s.interestSaved.toLocaleString(settings.locale, {
+                    style: 'currency',
+                    currency: settings.currency,
+                    maximumFractionDigits: 0,
+                  })}
+                  {s.paymentsSaved > 0 && ` and cut ${s.paymentsSaved} payments`}
+                  .
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -5,6 +5,9 @@ import { useFinance } from './FinanceContext'
 import { calculatePV, calculateLoanNPV, frequencyToPayments } from './utils/financeUtils'
 import { FREQUENCIES } from './constants'
 import suggestLoanStrategies from './utils/suggestLoanStrategies'
+import generateLoanAdvice from './utils/loanAdvisoryEngine'
+import AdviceDashboard from './AdviceDashboard'
+import calcDiscretionaryAdvice from './utils/discretionaryUtils'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend
@@ -29,6 +32,9 @@ export default function ExpensesGoalsTab() {
     liabilitiesList, setLiabilitiesList,
     setExpensesPV,
     profile,
+    monthlyExpense,
+    monthlyIncomeNominal,
+    monthlySurplusNominal,
     settings
   } = useFinance()
 
@@ -210,6 +216,30 @@ export default function ExpensesGoalsTab() {
   const totalLiabilitiesPV = liabilityDetails.reduce((s, l) => s + l.pv, 0)
   const totalRequired = pvExpensesLife + pvGoals + totalLiabilitiesPV
 
+  const loanAdvice = useMemo(
+    () =>
+      generateLoanAdvice(
+        liabilitiesList,
+        { ...profile, totalPV: pvExpensesLife },
+        monthlyIncomeNominal,
+        monthlyExpense,
+        discountRate,
+        lifeYears
+      ),
+    [liabilitiesList, profile, pvExpensesLife, monthlyIncomeNominal, monthlyExpense, discountRate, lifeYears]
+  )
+
+  const discretionaryAdvice = useMemo(
+    () =>
+      calcDiscretionaryAdvice(
+        expensesList,
+        monthlyExpense,
+        monthlySurplusNominal,
+        settings.discretionaryCutThreshold || 0
+      ),
+    [expensesList, monthlyExpense, monthlySurplusNominal, settings]
+  )
+
   const loanStrategies = useMemo(
     () => suggestLoanStrategies(liabilityDetails),
     [liabilityDetails]
@@ -250,6 +280,11 @@ export default function ExpensesGoalsTab() {
 
   return (
     <div className="space-y-8 p-6">
+      <AdviceDashboard
+        advice={loanAdvice}
+        discretionaryAdvice={discretionaryAdvice}
+        loanStrategies={loanStrategies}
+      />
 
       {/* Expenses CRUD */}
       <section>

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -18,6 +18,9 @@ import {
   calculatePVObligationSurvival
 } from './utils/survivalMetrics';
 import calcDiscretionaryAdvice from './utils/discretionaryUtils';
+import generateLoanAdvice from './utils/loanAdvisoryEngine'
+import suggestLoanStrategies from './utils/suggestLoanStrategies'
+import AdviceDashboard from './AdviceDashboard'
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
 } from 'recharts';
@@ -42,6 +45,8 @@ export default function IncomeTab() {
     includeLiabilitiesNPV,
     setIncludeLiabilitiesNPV,
     monthlySurplusNominal,
+    monthlyIncomeNominal,
+    profile,
     settings,
     expensesList,
     goalsList,
@@ -72,6 +77,24 @@ export default function IncomeTab() {
         const pv = i === 0 ? l.principal : payment * (1 - Math.pow(1 + i, -n)) / i;
         return sum + pv;
       }, 0),
+    [liabilitiesList]
+  );
+
+  const loanAdvice = useMemo(
+    () =>
+      generateLoanAdvice(
+        liabilitiesList,
+        { ...profile, totalPV: totalIncomePV },
+        monthlyIncomeNominal,
+        monthlyExpense,
+        discountRate,
+        years
+      ),
+    [liabilitiesList, profile, totalIncomePV, monthlyIncomeNominal, monthlyExpense, discountRate, years]
+  );
+
+  const loanStrategies = useMemo(
+    () => suggestLoanStrategies(liabilitiesList),
     [liabilitiesList]
   );
 
@@ -280,6 +303,11 @@ export default function IncomeTab() {
   // --- Render ---
   return (
     <div className="space-y-8">
+      <AdviceDashboard
+        advice={loanAdvice}
+        discretionaryAdvice={discretionaryAdvice}
+        loanStrategies={loanStrategies}
+      />
       {/* Income Streams Form */}
       <section>
         <h2 className="text-xl font-bold text-amber-700 mb-4">Income Sources</h2>

--- a/src/SettingsTab.jsx
+++ b/src/SettingsTab.jsx
@@ -3,7 +3,18 @@ import React, { useState, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
 
 export default function SettingsTab() {
-  const { settings, updateSettings } = useFinance()
+  const {
+    settings,
+    updateSettings,
+    includeMediumPV,
+    setIncludeMediumPV,
+    includeLowPV,
+    setIncludeLowPV,
+    includeGoalsPV,
+    setIncludeGoalsPV,
+    includeLiabilitiesNPV,
+    setIncludeLiabilitiesNPV,
+  } = useFinance()
   const [form, setForm] = useState(settings)
 
   // Whenever persisted settings change, reset the form
@@ -126,6 +137,46 @@ export default function SettingsTab() {
             title="Buffer percentage"
           />
         </label>
+
+        {/* PV Inclusion Options */}
+        <div className="md:col-span-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={includeMediumPV}
+              onChange={e => setIncludeMediumPV(e.target.checked)}
+            />
+            Include Medium Priority PV
+          </label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={includeLowPV}
+              onChange={e => setIncludeLowPV(e.target.checked)}
+            />
+            Include Low Priority PV
+          </label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={includeGoalsPV}
+              onChange={e => setIncludeGoalsPV(e.target.checked)}
+            />
+            Include Goals PV
+          </label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2"
+              checked={includeLiabilitiesNPV}
+              onChange={e => setIncludeLiabilitiesNPV(e.target.checked)}
+            />
+            Include Liabilities NPV
+          </label>
+        </div>
 
         {/* API Endpoint */}
         <label className="block md:col-span-2">


### PR DESCRIPTION
## Summary
- add new `AdviceDashboard` component
- compute loan advice in Income and Expenses/Goals tabs
- show financial advice through the dashboard
- expose PV inclusion checkboxes in Settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843667f79cc8323942b06e7151afb1e