### PR TITLE
Add frequency enum and advice docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,29 @@ npm run preview
 ## Tooling
 
 The project uses [React](https://react.dev/) with [Vite](https://vitejs.dev/) for the build system. Styling is powered by Tailwind CSS and ESLint provides linting rules.
+
+## Configuration
+
+Application settings are stored in local storage and can be modified under the **Settings** tab.  Available keys include:
+
+- `inflationRate` – annual inflation assumption used in PV calculations
+- `expectedReturn` – expected yearly portfolio return
+- `currency` – default ISO currency code
+- `locale` – locale for number formatting
+- `apiEndpoint` – URL to POST exported data
+- `discretionaryCutThreshold` – percentage of monthly expenses that triggers discretionary advice
+- `survivalThresholdMonths` – minimum months of PV coverage considered healthy
+- `bufferPct` – buffer percent applied to loan strategy comparisons
+
+## Advice Engine
+
+Utility modules under `src/utils` expose helper functions for generating spending and loan repayment advice.  The main entry point is `generateLoanAdvice`:
+
+```javascript
+import generateLoanAdvice from './src/utils/loanAdvisoryEngine'
+
+const advice = generateLoanAdvice(loans, profile, income, expenses, discountRate, years)
+console.log(advice.dti, advice.survival)
+```
+
+`calcDiscretionaryAdvice` suggests low‑priority expenses to cut when the monthly surplus falls below the configured threshold. `suggestLoanStrategies` ranks liabilities by interest saved when paying them off early.

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -2,8 +2,8 @@
 
 import React, { useMemo, useEffect } from 'react'
 import { useFinance } from './FinanceContext'
-import { calculatePV, calculateLoanNPV, frequencyToPayments } from './utils/financeUtils'
-import { FREQUENCIES } from './constants'
+import { calculatePV, calculateLoanNPV } from './utils/financeUtils'
+import { FREQUENCIES, FREQUENCY_LABELS } from './constants'
 import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import generateLoanAdvice from './utils/loanAdvisoryEngine'
 import AdviceDashboard from './AdviceDashboard'
@@ -488,8 +488,8 @@ export default function ExpensesGoalsTab() {
             onChange={ev => handleLiabilityChange(i, 'paymentsPerYear', ev.target.value)}
             title="Payments per year"
           >
-            {FREQUENCIES.map(f => (
-              <option key={f} value={frequencyToPayments(f)}>{f}</option>
+            {FREQUENCY_LABELS.map(label => (
+              <option key={label} value={FREQUENCIES[label]}>{label}</option>
             ))}
           </select>
             <input

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,11 @@
-export const FREQUENCIES = ['Monthly', 'Quarterly', 'Annually']
+// Common payment frequencies and their payments per year.
+// Used by forms and the finance utilities.
+export const FREQUENCIES = {
+  Monthly: 12,
+  Quarterly: 4,
+  Annually: 1,
+}
+
+// Convenience list of labels for dropdowns
+export const FREQUENCY_LABELS = Object.keys(FREQUENCIES)
 

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -3,6 +3,8 @@
  * Shared financial formulas for present-value and related calculations.
  */
 
+import { FREQUENCIES } from '../constants'
+
 /**
  * Calculate present value of a growing annuity.
  *
@@ -36,9 +38,9 @@ export function calculatePV(amount, frequency, growthRate, discountRate, periods
  * @returns {number} Payments per year (0 if invalid).
  */
 export function frequencyToPayments(freq) {
-  if (typeof freq === 'number') return freq > 0 ? freq : 0;
-  const map = { Monthly: 12, Quarterly: 4, Annually: 1 };
-  return map[freq] ?? 0;
+  if (typeof freq === 'number') return freq > 0 ? freq : 0
+  // FREQUENCIES maps labels to payments per year
+  return FREQUENCIES[freq] ?? 0
 }
 
 


### PR DESCRIPTION
## Summary
- add FREQUENCIES map and export labels
- adjust liabilities form to use new map
- read FREQUENCIES in finance utilities
- document config options and advice utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68436858d4a88323b8dc6f9142dacd6b