### PR TITLE
Add IDs for balance sheet rows

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -17,9 +17,9 @@ export default function BalanceSheetTab() {
   // Keep PV of Lifetime Income in sync with context changes
   useEffect(() => {
     setAssetsList(prev => {
-      const idx = prev.findIndex(a => a.name === 'PV of Lifetime Income')
+      const idx = prev.findIndex(a => a.id === 'pv-income')
       if (idx === -1) {
-        return [...prev, { name: 'PV of Lifetime Income', amount: incomePV }]
+        return [...prev, { id: 'pv-income', name: 'PV of Lifetime Income', amount: incomePV }]
       }
       const updated = [...prev]
       updated[idx] = { ...updated[idx], amount: incomePV }
@@ -30,9 +30,9 @@ export default function BalanceSheetTab() {
   // Keep PV of Lifetime Expenses in sync with context changes
   useEffect(() => {
     setLiabilitiesList(prev => {
-      const idx = prev.findIndex(l => l.name === 'PV of Lifetime Expenses')
+      const idx = prev.findIndex(l => l.id === 'pv-expenses')
       if (idx === -1) {
-        return [...prev, { name: 'PV of Lifetime Expenses', amount: expensesPV }]
+        return [...prev, { id: 'pv-expenses', name: 'PV of Lifetime Expenses', amount: expensesPV }]
       }
       const updated = [...prev]
       updated[idx] = { ...updated[idx], amount: expensesPV }
@@ -44,8 +44,10 @@ export default function BalanceSheetTab() {
   const totalLiabilities = liabilitiesList.reduce((sum, l) => sum + Number(l.amount || 0), 0)
   const netWorth = totalAssets - totalLiabilities
 
-  const addAsset = () => setAssetsList([...assetsList, { name: '', amount: 0 }])
-  const addLiability = () => setLiabilitiesList([...liabilitiesList, { name: '', amount: 0 }])
+  const addAsset = () =>
+    setAssetsList([...assetsList, { id: crypto.randomUUID(), name: '', amount: 0 }])
+  const addLiability = () =>
+    setLiabilitiesList([...liabilitiesList, { id: crypto.randomUUID(), name: '', amount: 0 }])
 
   const updateItem = (setList, list, index, field, value) => {
     const updated = list.map((it, i) =>
@@ -73,11 +75,12 @@ export default function BalanceSheetTab() {
         <div>
           <h3 className="text-md font-medium mb-2">Assets</h3>
           {assetsList.map((item, i) => (
-            <div key={i} className="flex space-x-2 mb-2">
+            <div key={item.id} className="flex space-x-2 mb-2">
               <input
                 className="border p-2 rounded-md w-1/2"
                 value={item.name}
                 onChange={e => updateItem(setAssetsList, assetsList, i, 'name', e.target.value)}
+                disabled={item.id === 'pv-income'}
                 title="Asset name"
               />
               <input
@@ -102,11 +105,12 @@ export default function BalanceSheetTab() {
         <div>
           <h3 className="text-md font-medium mb-2">Liabilities</h3>
           {liabilitiesList.map((item, i) => (
-            <div key={i} className="flex space-x-2 mb-2">
+            <div key={item.id} className="flex space-x-2 mb-2">
               <input
                 className="border p-2 rounded-md w-1/2"
                 value={item.name}
                 onChange={e => updateItem(setLiabilitiesList, liabilitiesList, i, 'name', e.target.value)}
+                disabled={item.id === 'pv-expenses'}
                 title="Liability name"
               />
               <input

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -129,6 +129,7 @@ export default function ExpensesGoalsTab() {
   }
   const addLiability = () =>
     setLiabilitiesList([...liabilitiesList, {
+      id: crypto.randomUUID(),
       name: '', principal: 0, interestRate: 0, termYears: 1,
       remainingMonths: 12, paymentsPerYear: 12, payment: 0
     }])
@@ -443,7 +444,7 @@ export default function ExpensesGoalsTab() {
           <p className="italic text-slate-500 col-span-full mb-2">No loans added</p>
         )}
         {liabilityDetails.map((l, i) => (
-          <div key={i} className="grid grid-cols-1 sm:grid-cols-10 gap-2 items-center mb-1">
+          <div key={l.id} className="grid grid-cols-1 sm:grid-cols-10 gap-2 items-center mb-1">
             <input
               className="border p-2 rounded-md"
               placeholder="Car Loan"
@@ -540,8 +541,8 @@ export default function ExpensesGoalsTab() {
       {/* Amortization Schedules */}
       <section>
         <h2 className="text-xl font-bold text-amber-700 mb-4">Loan Amortization</h2>
-        {liabilityDetails.map((l, idx) => (
-          <div key={idx} className="mb-8">
+        {liabilityDetails.map(l => (
+          <div key={l.id} className="mb-8">
             <h3 className="text-lg font-semibold">{l.name}</h3>
             <ResponsiveContainer width="100%" height={200}>
               <BarChart data={l.schedule}>

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -117,19 +117,33 @@ export function FinanceProvider({ children }) {
   // === Balance Sheet assets state ===
   const [assetsList, setAssetsList] = useState(() => {
     const s = localStorage.getItem('assetsList')
-    return s
-      ? JSON.parse(s)
-      : [
-          { name: 'Cash', amount: 500000 },
-          { name: 'Investments', amount: 1000000 },
-          { name: 'PV of Lifetime Income', amount: 0 },
-        ]
+    if (s) {
+      try {
+        const parsed = JSON.parse(s)
+        return parsed.map(a => ({ id: a.id || crypto.randomUUID(), ...a }))
+      } catch {
+        // ignore malformed stored data
+      }
+    }
+    return [
+      { id: crypto.randomUUID(), name: 'Cash', amount: 500000 },
+      { id: crypto.randomUUID(), name: 'Investments', amount: 1000000 },
+      { id: 'pv-income', name: 'PV of Lifetime Income', amount: 0 },
+    ]
   })
 
   // === Liabilities (Loans) state ===
   const [liabilitiesList, setLiabilitiesList] = useState(() => {
     const s = localStorage.getItem('liabilitiesList')
-    return s ? JSON.parse(s) : []
+    if (s) {
+      try {
+        const parsed = JSON.parse(s)
+        return parsed.map(l => ({ id: l.id || crypto.randomUUID(), ...l }))
+      } catch {
+        // ignore malformed stored data
+      }
+    }
+    return []
   })
 
   // === Profile & KYC fields (with lifeExpectancy) ===
@@ -332,10 +346,24 @@ export function FinanceProvider({ children }) {
     if (sG) setGoalsList(JSON.parse(sG))
 
     const sA = localStorage.getItem('assetsList')
-    if (sA) setAssetsList(JSON.parse(sA))
+    if (sA) {
+      try {
+        const parsed = JSON.parse(sA)
+        setAssetsList(parsed.map(a => ({ id: a.id || crypto.randomUUID(), ...a })))
+      } catch {
+        // ignore malformed stored data
+      }
+    }
 
     const sL = localStorage.getItem('liabilitiesList')
-    if (sL) setLiabilitiesList(JSON.parse(sL))
+    if (sL) {
+      try {
+        const parsed = JSON.parse(sL)
+        setLiabilitiesList(parsed.map(l => ({ id: l.id || crypto.randomUUID(), ...l })))
+      } catch {
+        // ignore malformed stored data
+      }
+    }
 
     const me = localStorage.getItem('monthlyExpense')
     if (me) setMonthlyExpense(+me)


### PR DESCRIPTION
## Summary
- add persistent `id` to asset and liability entries
- use IDs to sync PV rows and disable editing
- include IDs when adding liabilities in Expenses tab

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684376336cb083239fe3fdba2100de95