### PR TITLE
Add investment strategy lookup

### DIFF
--- a/src/__tests__/investmentStrategies.test.js
+++ b/src/__tests__/investmentStrategies.test.js
@@ -1,0 +1,11 @@
+/* global test, expect */
+import InvestmentStrategies, { getStrategyWeights } from '../investmentStrategies'
+
+test('returns strategy weights when found', () => {
+  const weights = getStrategyWeights('Conservative')
+  expect(weights).toBe(InvestmentStrategies.Conservative)
+})
+
+test('returns null for unknown strategy', () => {
+  expect(getStrategyWeights('Unknown')).toBeNull()
+})

--- a/src/investmentStrategies.js
+++ b/src/investmentStrategies.js
@@ -1,0 +1,41 @@
+// src/investmentStrategies.js
+// Example portfolio mixes by risk profile.
+
+export const InvestmentStrategies = {
+  Conservative: {
+    'US Equity': 20,
+    'Global Equity': 15,
+    'Emerging Markets': 5,
+    'US Bonds': 45,
+    'Global Bonds': 10,
+    Cash: 5
+  },
+  Balanced: {
+    'US Equity': 35,
+    'Global Equity': 20,
+    'Emerging Markets': 10,
+    'US Bonds': 25,
+    'Global Bonds': 5,
+    Cash: 5
+  },
+  Growth: {
+    'US Equity': 50,
+    'Global Equity': 25,
+    'Emerging Markets': 15,
+    'US Bonds': 5,
+    'Global Bonds': 5,
+    Cash: 0
+  }
+}
+
+/**
+ * Retrieve portfolio weights for a given strategy name.
+ *
+ * @param {string} name - Strategy key (Conservative/Balanced/Growth).
+ * @returns {Object|null} Allocation weights or null if unknown.
+ */
+export function getStrategyWeights(name) {
+  return InvestmentStrategies[name] || null
+}
+
+export default InvestmentStrategies


### PR DESCRIPTION
## Summary
- define common investment mixes in `src/investmentStrategies.js`
- provide `getStrategyWeights` helper
- test the lookup function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684379c81e708323be1aacc5c30629ca