### PR TITLE
Add default horizon for new assets

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -10,6 +10,7 @@ export default function BalanceSheetTab() {
     expensesPV,
     assetsList,
     setAssetsList,
+    createAsset,
     liabilitiesList,
     setLiabilitiesList,
   } = useFinance()
@@ -45,7 +46,7 @@ export default function BalanceSheetTab() {
   const netWorth = totalAssets - totalLiabilities
 
   const addAsset = () =>
-    setAssetsList([...assetsList, { id: crypto.randomUUID(), name: '', amount: 0 }])
+    setAssetsList([...assetsList, createAsset()])
   const addLiability = () =>
     setLiabilitiesList([...liabilitiesList, { id: crypto.randomUUID(), name: '', amount: 0 }])
 

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -194,6 +194,14 @@ export function FinanceProvider({ children }) {
     }
   })
 
+  // Utility to create a new asset with defaults
+  const createAsset = () => ({
+    id: crypto.randomUUID(),
+    name: '',
+    amount: 0,
+    horizonYears: profile.lifeExpectancy - profile.age,
+  })
+
   // === Settings state ===
   const [settings, setSettings] = useState(() => {
     const s = localStorage.getItem('settings')
@@ -470,6 +478,7 @@ export function FinanceProvider({ children }) {
       expensesList,  setExpensesList,
       goalsList,     setGoalsList,
       assetsList,    setAssetsList,
+      createAsset,
 
       // Liabilities
       liabilitiesList, setLiabilitiesList,


### PR DESCRIPTION
## Summary
- add `createAsset` utility in `FinanceContext` that sets `horizonYears` using the user's profile
- expose `createAsset` via context
- use `createAsset` when adding assets in `BalanceSheetTab`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437be08ba8832383637aa3bac808f7