### PR TITLE
Add edge case tests for future value helpers

### DIFF
--- a/src/__tests__/futureValue.test.js
+++ b/src/__tests__/futureValue.test.js
@@ -21,3 +21,21 @@ test('compounding and discount are inverse operations', () => {
   const pv = discountToPresent(fv, rate, years)
   expect(pv).toBeCloseTo(amount)
 })
+
+test('estimateFutureValue returns principal when rate is zero', () => {
+  expect(estimateFutureValue(750, 0, 5)).toBe(750)
+})
+
+test('discountToPresent returns same amount when rate is zero', () => {
+  expect(discountToPresent(750, 0, 5)).toBe(750)
+})
+
+test('estimateFutureValue handles negative years', () => {
+  const fv = estimateFutureValue(1000, 5, -2)
+  expect(fv).toBeCloseTo(1000 * Math.pow(1 + 0.05, -2))
+})
+
+test('discountToPresent handles negative years', () => {
+  const pv = discountToPresent(1000, 5, -2)
+  expect(pv).toBeCloseTo(1000 / Math.pow(1 + 0.05, -2))
+})


### PR DESCRIPTION
## Summary
- extend `futureValue.test.js` with zero-rate and negative-year cases for `estimateFutureValue` and `discountToPresent`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684410f62b488323a6268ee660d6664d