### PR TITLE
Clamp frequency values

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -239,8 +239,11 @@ export default function IncomeTab() {
       if (field === 'name' || field === 'type') {
         return { ...src, [field]: raw };
       }
-      const val = parseFloat(raw);
-      return { ...src, [field]: isNaN(val) ? 0 : Math.max(0, val) };
+      const num = parseFloat(raw);
+      if (field === 'frequency') {
+        return { ...src, [field]: isNaN(num) ? 1 : Math.max(1, num) };
+      }
+      return { ...src, [field]: isNaN(num) ? 0 : Math.max(0, num) };
     });
     setIncomeSources(updated);
   };
@@ -363,7 +366,7 @@ export default function IncomeTab() {
                 className="w-full border p-2 rounded-md invalid:border-red-500"
                 value={src.frequency}
                 onChange={e => onFieldChange(i, 'frequency', e.target.value)}
-                min={0}
+                min={1}
                 step={1}
                 required
                 title="Payments per year"

--- a/src/__tests__/incomeTab.frequency.test.js
+++ b/src/__tests__/incomeTab.frequency.test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import IncomeTab from '../IncomeTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
+test('frequency below 1 is corrected to 1', () => {
+  render(
+    <FinanceProvider>
+      <IncomeTab />
+    </FinanceProvider>
+  )
+
+  const input = screen.getAllByTitle('Payments per year')[0]
+  fireEvent.change(input, { target: { value: '0' } })
+  expect(input.value).toBe('1')
+})


### PR DESCRIPTION
## Summary
- clamp `frequency` changes to at least 1
- enforce `min={1}` on frequency inputs
- add Jest test ensuring clamped frequency

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844171d4bac8323bbe49aee5a5b0d21