### PR TITLE
Disable editing PV income amount

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -238,6 +238,7 @@ export default function BalanceSheetTab() {
                 className="border p-2 rounded-md text-right"
                 value={item.amount}
                 onChange={e => updateItem(setAssetsList, assetsList, i, 'amount', e.target.value)}
+                disabled={item.id === 'pv-income'}
                 title="Asset amount"
               />
               <select


### PR DESCRIPTION
## Summary
- prevent editing the amount for the automatically calculated "PV of Lifetime Income" asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844182a8bf483239e2fd9ca8c80327f