### PR TITLE
Enforce valid life expectancy

### DIFF
--- a/src/ProfileTab.jsx
+++ b/src/ProfileTab.jsx
@@ -14,6 +14,13 @@ export default function ProfileTab() {
   // Handle any field change locally, then persist via context
   const handleChange = (field, value) => {
     const updated = { ...form, [field]: value }
+
+    if (field === 'lifeExpectancy' && value <= updated.age) {
+      updated.lifeExpectancy = updated.age + 1
+    } else if (field === 'age' && updated.lifeExpectancy <= value) {
+      updated.lifeExpectancy = value + 1
+    }
+
     setForm(updated)
     updateProfile(updated)
   }

--- a/src/__tests__/profileTab.lifeExpectancy.test.js
+++ b/src/__tests__/profileTab.lifeExpectancy.test.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import ProfileTab from '../ProfileTab'
+
+beforeAll(() => {
+  // ensure ResizeObserver not required
+  global.ResizeObserver = class { observe(){} unobserve(){} disconnect(){} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+test('life expectancy below age is adjusted to age + 1', () => {
+  render(
+    <FinanceProvider>
+      <ProfileTab />
+    </FinanceProvider>
+  )
+
+  const ageInput = screen.getByTitle('Age')
+  const lifeInput = screen.getByTitle('Life Expectancy')
+
+  fireEvent.change(ageInput, { target: { value: '60' } })
+  fireEvent.change(lifeInput, { target: { value: '58' } })
+
+  expect(lifeInput.value).toBe('61')
+})
+
+test('increasing age past expectancy adjusts expectancy', () => {
+  render(
+    <FinanceProvider>
+      <ProfileTab />
+    </FinanceProvider>
+  )
+
+  const ageInput = screen.getByTitle('Age')
+  const lifeInput = screen.getByTitle('Life Expectancy')
+
+  fireEvent.change(lifeInput, { target: { value: '40' } })
+  fireEvent.change(ageInput, { target: { value: '41' } })
+
+  expect(lifeInput.value).toBe('42')
+})


### PR DESCRIPTION
## Summary
- validate `lifeExpectancy` in `ProfileTab` so it always exceeds `age`
- add unit tests covering this validation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68441b078b2083239a3b3f090c6953cc