### PR TITLE
Fix CSV export quoting

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -12,6 +12,7 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { useFinance } from './FinanceContext';
 import { calculatePV } from './utils/financeUtils';
+import { buildCSV } from './utils/csvUtils'
 import {
   calculateNominalSurvival,
   calculatePVSurvival,
@@ -282,11 +283,11 @@ export default function IncomeTab() {
   };
 
   const exportCSV = () => {
-    const columns = ['Period', ...incomeSources.map((src, i) => src.name || `Source ${i + 1}`)];
+    const columns = ['Period', ...incomeSources.map((src, i) => src.name || `Source ${i + 1}`)]
     const rows = incomeData.map(row =>
-      columns.map(col => (col === 'Period' ? row.year : row[col])).join(',')
-    );
-    const csv = [columns.join(','), ...rows].join('\n');
+      columns.map(col => (col === 'Period' ? row.year : row[col]))
+    )
+    const csv = buildCSV(columns, rows)
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/src/__tests__/csvUtils.test.js
+++ b/src/__tests__/csvUtils.test.js
@@ -1,0 +1,14 @@
+import { buildCSV } from '../utils/csvUtils'
+
+test('buildCSV escapes commas and quotes', () => {
+  const csv = buildCSV(
+    ['Col,1', 'Col"2"'],
+    [
+      ['Value,1', 'He said "ok"']
+    ]
+  )
+  expect(csv).toBe(
+    '"Col,1","Col""2"""\n"Value,1","He said ""ok"""'
+  )
+})
+

--- a/src/utils/csvUtils.js
+++ b/src/utils/csvUtils.js
@@ -1,0 +1,10 @@
+export function quoteCSV(value) {
+  return `"${String(value).replace(/"/g, '""')}"`
+}
+
+export function buildCSV(columns = [], rows = []) {
+  const header = columns.map(quoteCSV).join(',')
+  const data = rows.map(row => row.map(quoteCSV).join(','))
+  return [header, ...data].join('\n')
+}
+


### PR DESCRIPTION
## Summary
- escape and quote values when generating CSV files
- expose helper for CSV creation
- add tests for CSV quoting

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68442bac02a88323b7952b42a486d37f