### PR TITLE
Add reusable currency formatter

### DIFF
--- a/src/AdviceDashboard.jsx
+++ b/src/AdviceDashboard.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useFinance } from './FinanceContext'
+import { formatCurrency } from './utils/formatters'
 
 export default function AdviceDashboard({ advice, discretionaryAdvice = [], loanStrategies = [] }) {
   const { settings } = useFinance()
@@ -32,11 +33,7 @@ export default function AdviceDashboard({ advice, discretionaryAdvice = [], loan
               {discretionaryAdvice.map((d, i) => (
                 <li key={i} className="text-sm">
                   Cut <strong>{d.name}</strong> (~
-                  {d.amount.toLocaleString(settings.locale, {
-                    style: 'currency',
-                    currency: settings.currency,
-                    maximumFractionDigits: 0,
-                  })}
+                  {formatCurrency(d.amount, settings.locale, settings.currency)}
                   /mo)
                 </li>
               ))}
@@ -50,11 +47,7 @@ export default function AdviceDashboard({ advice, discretionaryAdvice = [], loan
               {loanStrategies.map((s, i) => (
                 <li key={i} className="text-sm">
                   Pay <strong>{s.name}</strong> early to save{' '}
-                  {s.interestSaved.toLocaleString(settings.locale, {
-                    style: 'currency',
-                    currency: settings.currency,
-                    maximumFractionDigits: 0,
-                  })}
+                  {formatCurrency(s.interestSaved, settings.locale, settings.currency)}
                   {s.paymentsSaved > 0 && ` and cut ${s.paymentsSaved} payments`}
                   .
                 </li>

--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -14,6 +14,7 @@ import {
 import { useFinance } from './FinanceContext'
 import LTCMA from './ltcmaAssumptions'
 import InvestmentStrategies from './investmentStrategies'
+import { formatCurrency } from './utils/formatters'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 
@@ -29,6 +30,7 @@ export default function BalanceSheetTab() {
     goalsList,
     discountRate,
     humanCapitalShare,
+    settings,
   } = useFinance()
 
   const [strategy, setStrategy] = useState('')
@@ -318,7 +320,7 @@ export default function BalanceSheetTab() {
       </div>
 
       <div className="text-md text-slate-700 italic">
-        Net Worth: <span className="text-2xl font-bold text-amber-700">KES {netWorth.toLocaleString()}</span>
+        Net Worth: <span className="text-2xl font-bold text-amber-700">{formatCurrency(netWorth, settings.locale, settings.currency)}</span>
         {debtAssetRatio > 1 && (
           <span className="block text-red-600 text-sm">Warning: Debt exceeds assets ({(debtAssetRatio * 100).toFixed(1)}%).</span>
         )}
@@ -333,7 +335,7 @@ export default function BalanceSheetTab() {
                 {row.label === 'Debt/Asset Ratio'
                   ? `${(row.value * 100).toFixed(1)}%`
                   : typeof row.value === 'number'
-                  ? row.value.toLocaleString(undefined, { maximumFractionDigits: 2 })
+                  ? formatCurrency(row.value, settings.locale, settings.currency)
                   : row.value}
               </td>
             </tr>

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -1,6 +1,7 @@
 // src/ExpensesGoalsTab.jsx
 
 import React, { useMemo, useEffect } from 'react'
+import { formatCurrency } from './utils/formatters'
 import { useFinance } from './FinanceContext'
 import { calculatePV, calculateLoanNPV } from './utils/financeUtils'
 import { FREQUENCIES, FREQUENCY_LABELS } from './constants'
@@ -527,10 +528,10 @@ export default function ExpensesGoalsTab() {
           <BarChart data={pvSummaryData} margin={{ top:20, right:30, left:0, bottom:20 }}>
             <XAxis dataKey="category" />
             <YAxis tickFormatter={v =>
-              v.toLocaleString(settings.locale,{style:'currency',currency:settings.currency})
+              formatCurrency(v, settings.locale, settings.currency)
             }/>
             <Tooltip formatter={v =>
-              v.toLocaleString(settings.locale,{style:'currency',currency:settings.currency})
+              formatCurrency(v, settings.locale, settings.currency)
             }/>
             <Legend />
             <Bar dataKey="value" fill={COLORS[1]} name="Present Value" />
@@ -548,10 +549,10 @@ export default function ExpensesGoalsTab() {
               <BarChart data={l.schedule}>
                 <XAxis dataKey="year" />
                 <YAxis tickFormatter={v =>
-                  v.toLocaleString(settings.locale,{style:'currency',currency:settings.currency})
+                  formatCurrency(v, settings.locale, settings.currency)
                 }/>
                 <Tooltip formatter={v =>
-                  v.toLocaleString(settings.locale,{style:'currency',currency:settings.currency})
+                  formatCurrency(v, settings.locale, settings.currency)
                 }/>
                 <Legend verticalAlign="bottom" />
                 <Bar dataKey="principalPaid" stackId="a" name="Principal" fill={PRINCIPAL_COLOR} />
@@ -573,9 +574,7 @@ export default function ExpensesGoalsTab() {
           <div key={i} className="bg-white rounded-xl shadow p-4 flex flex-col items-center">
             <span className="text-sm text-gray-500">{it.label}</span>
             <span className="mt-2 text-lg font-semibold text-amber-700">
-              {it.value.toLocaleString(settings.locale,{
-                style:'currency',currency:settings.currency,maximumFractionDigits:0
-              })}
+              {formatCurrency(it.value, settings.locale, settings.currency)}
             </span>
           </div>
         ))}
@@ -589,11 +588,7 @@ export default function ExpensesGoalsTab() {
               <li key={i}>
                 Pay <strong>{s.name}</strong> early to save&nbsp;
                 <span className="text-amber-700 font-semibold">
-                  {s.interestSaved.toLocaleString(settings.locale, {
-                    style: 'currency',
-                    currency: settings.currency,
-                    maximumFractionDigits: 0
-                  })}
+                  {formatCurrency(s.interestSaved, settings.locale, settings.currency)}
                 </span>
                 {s.paymentsSaved > 0 && ` and cut ${s.paymentsSaved} payments`}
                 .

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -25,6 +25,7 @@ import AdviceDashboard from './AdviceDashboard'
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
 } from 'recharts';
+import { formatCurrency } from './utils/formatters'
 
 export default function IncomeTab() {
   const {
@@ -467,17 +468,13 @@ export default function IncomeTab() {
             Monthly Expenses (from Expenses tab):
             <span className="font-semibold text-amber-700">
               {' '}
-              {monthlyExpense.toLocaleString(settings.locale, {
-                style: 'currency', currency: settings.currency
-              })}
+              {formatCurrency(monthlyExpense, settings.locale, settings.currency)}
             </span>
           </p>
           <p className="text-sm italic text-slate-500 mt-1">
             PV-Adjusted Monthly Expense:&nbsp;
             <span className="font-semibold text-amber-700">
-              {monthlyPVExpense.toLocaleString(settings.locale, {
-                style: 'currency', currency: settings.currency
-              })}
+              {formatCurrency(monthlyPVExpense, settings.locale, settings.currency)}
             </span>
           </p>
         </div>
@@ -556,9 +553,7 @@ export default function IncomeTab() {
             <li key={i}>
               {src.name || `Source ${i+1}`}:&nbsp;
               <span className="text-green-600 font-semibold">
-                {pvPerStream[i].toLocaleString(settings.locale, {
-                  style: 'currency', currency: settings.currency
-                })}
+                {formatCurrency(pvPerStream[i], settings.locale, settings.currency)}
               </span>
             </li>
           ))}
@@ -566,9 +561,7 @@ export default function IncomeTab() {
         <p className="mt-4 font-semibold">
           Total PV:&nbsp;
           <span className="text-green-600 text-xl">
-            {totalPV.toLocaleString(settings.locale, {
-              style: 'currency', currency: settings.currency
-            })}
+            {formatCurrency(totalPV, settings.locale, settings.currency)}
           </span>
         </p>
         <p className="text-sm mt-2" title="Months covered ignoring discounting">
@@ -624,11 +617,7 @@ export default function IncomeTab() {
             {discretionaryAdvice.map((d, i) => (
               <li key={i}>
                 Cut <strong>{d.name}</strong> (~
-                {d.amount.toLocaleString(settings.locale, {
-                  style: 'currency',
-                  currency: settings.currency,
-                  maximumFractionDigits: 0
-                })}
+                {formatCurrency(d.amount, settings.locale, settings.currency)}
                 /mo)
               </li>
             ))}
@@ -646,9 +635,7 @@ export default function IncomeTab() {
             <XAxis dataKey="year" />
             <YAxis />
             <Tooltip formatter={value =>
-              value.toLocaleString(settings.locale, {
-                style: 'currency', currency: settings.currency
-              })
+              formatCurrency(value, settings.locale, settings.currency)
             } />
             <Legend />
             {incomeSources.map((src, i) => (

--- a/src/__tests__/formatters.test.js
+++ b/src/__tests__/formatters.test.js
@@ -1,0 +1,11 @@
+import { formatCurrency } from '../utils/formatters'
+
+test('rounds values to two decimals', () => {
+  expect(formatCurrency(1234.567, 'en-US', 'USD')).toBe('$1,234.57')
+  expect(formatCurrency(-987.654, 'en-US', 'USD')).toBe('-$987.65')
+})
+
+test('formats millions with suffix', () => {
+  expect(formatCurrency(1234567, 'en-US', 'USD')).toBe('1.23 M')
+  expect(formatCurrency(-9876543, 'en-US', 'USD')).toBe('-9.88 M')
+})

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,12 @@
+export function formatCurrency(value, locale = 'en-US', currency = 'USD') {
+  const abs = Math.abs(value)
+  if (abs >= 1_000_000) {
+    const formatted = new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(value / 1_000_000)
+    return `${formatted} M`
+  }
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2
+  }).format(value)
+}


### PR DESCRIPTION
## Summary
- add `formatCurrency` utility with million suffix support
- test formatter rounding and million formatting
- format currency values in AdviceDashboard, BalanceSheetTab, ExpensesGoalsTab and IncomeTab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684433d07f10832383a61050aabb8b9e