### PR TITLE
Initialize strategy on BalanceSheet mount

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -31,10 +31,19 @@ export default function BalanceSheetTab() {
     discountRate,
     humanCapitalShare,
     settings,
+    riskScore,
   } = useFinance()
 
   const [strategy, setStrategy] = useState('')
   const [expandedAssets, setExpandedAssets] = useState({})
+
+  // Initialize strategy based on risk score once on mount
+  useEffect(() => {
+    if (strategy) return
+    if (riskScore <= 6) setStrategy('Conservative')
+    else if (riskScore <= 12) setStrategy('Balanced')
+    else setStrategy('Growth')
+  }, [riskScore, strategy])
 
   const assetReturn = useMemo(() => {
     const total = assetsList.reduce((s, a) => s + Number(a.amount || 0), 0)


### PR DESCRIPTION
## Summary
- consume `riskScore` from `useFinance`
- set initial strategy based on risk score

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684436536f108323a17fef3772c0004d