### PR TITLE
Improve a11y and responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ export default function App() {
             aria-selected={activeTab === tab}
             key={tab}
             onClick={() => setActiveTab(tab)}
-            className={`px-3 py-1 rounded-t ${
+            className={`px-3 py-1 rounded-t focus:outline-none focus:ring-2 focus:ring-amber-500 ${
               activeTab === tab
                 ? 'bg-white shadow text-amber-700'
                 : 'text-slate-500 hover:text-amber-700'

--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -215,6 +215,7 @@ export default function BalanceSheetTab() {
           className="border p-2 rounded-md"
           value={strategy}
           onChange={e => setStrategy(e.target.value)}
+          aria-label="Strategy"
         >
           <option value="">-- Select --</option>
           {Object.keys(InvestmentStrategies).map(s => (
@@ -240,17 +241,22 @@ export default function BalanceSheetTab() {
           {assetsList.map((item, i) => (
             <React.Fragment key={item.id}>
               <div
-                className={`grid grid-cols-4 gap-2 mb-1 items-center ${
-                  item.id === 'pv-income' ? 'italic bg-slate-100' : ''
+                className={`grid grid-cols-1 sm:grid-cols-4 gap-2 mb-1 items-center ${
+                  item.id === 'pv-income'
+                    ? 'italic bg-slate-100'
+                    : 'border rounded-md p-2 sm:p-0'
                 }`}
               >
                 <button
                   onClick={() => toggleAsset(item.id)}
                   aria-expanded={expandedAssets[item.id] ? 'true' : 'false'}
-                  className="text-amber-700 focus:outline-none"
+                  className="text-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
                   title="Toggle details"
                 >
-                  {expandedAssets[item.id] ? '▾' : '▸'}
+                  <span className="hidden sm:inline">{expandedAssets[item.id] ? '▾' : '▸'}</span>
+                  <span className="sm:hidden text-sm underline">
+                    {expandedAssets[item.id] ? 'Hide' : 'Details'}
+                  </span>
                 </button>
                 <input
                   className="border p-2 rounded-md"
@@ -258,6 +264,7 @@ export default function BalanceSheetTab() {
                   onChange={e => updateItem(setAssetsList, assetsList, i, 'name', e.target.value)}
                   disabled={item.id === 'pv-income'}
                   aria-disabled={item.id === 'pv-income' ? 'true' : undefined}
+                  aria-label="Asset name"
                   title="Asset name"
                 />
                 <input
@@ -267,6 +274,7 @@ export default function BalanceSheetTab() {
                   onChange={e => updateItem(setAssetsList, assetsList, i, 'amount', e.target.value)}
                   disabled={item.id === 'pv-income'}
                   aria-disabled={item.id === 'pv-income' ? 'true' : undefined}
+                  aria-label="Asset amount"
                   title="Asset amount"
                 />
                 <select
@@ -275,6 +283,7 @@ export default function BalanceSheetTab() {
                   onChange={e => updateItem(setAssetsList, assetsList, i, 'type', e.target.value)}
                   disabled={item.id === 'pv-income'}
                   aria-disabled={item.id === 'pv-income' ? 'true' : undefined}
+                  aria-label="Asset type"
                   title="Asset type"
                 >
                   <option value=""></option>
@@ -284,12 +293,13 @@ export default function BalanceSheetTab() {
                 </select>
               </div>
               {expandedAssets[item.id] && (
-                <div className="grid grid-cols-3 gap-2 mb-2 ml-6">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mb-2 ml-4 sm:ml-6 border-t pt-2 sm:border-none">
                   <input
                     type="number"
                     className="border p-2 rounded-md text-right"
                     value={item.expectedReturn}
                     onChange={e => updateItem(setAssetsList, assetsList, i, 'expectedReturn', e.target.value)}
+                    aria-label="Expected return"
                     title="Expected return"
                   />
                   <input
@@ -297,6 +307,7 @@ export default function BalanceSheetTab() {
                     className="border p-2 rounded-md text-right"
                     value={item.volatility}
                     onChange={e => updateItem(setAssetsList, assetsList, i, 'volatility', e.target.value)}
+                    aria-label="Volatility"
                     title="Volatility"
                   />
                   <input
@@ -304,6 +315,7 @@ export default function BalanceSheetTab() {
                     className="border p-2 rounded-md text-right"
                     value={item.horizonYears ?? ''}
                     onChange={e => updateItem(setAssetsList, assetsList, i, 'horizonYears', e.target.value)}
+                    aria-label="Horizon years"
                     title="Horizon years"
                   />
                 </div>
@@ -312,7 +324,7 @@ export default function BalanceSheetTab() {
           ))}
           <button
             onClick={addAsset}
-            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700"
+            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
             aria-label="Add asset"
             title="Add asset"
           >
@@ -325,8 +337,10 @@ export default function BalanceSheetTab() {
           {liabilitiesList.map((item, i) => (
             <div
               key={item.id}
-              className={`grid grid-cols-2 gap-2 mb-2 items-center ${
-                item.id === 'pv-expenses' ? 'italic bg-slate-100' : ''
+              className={`grid grid-cols-1 sm:grid-cols-2 gap-2 mb-2 items-center ${
+                item.id === 'pv-expenses'
+                  ? 'italic bg-slate-100'
+                  : 'border rounded-md p-2 sm:p-0'
               }`}
             >
               <input
@@ -335,6 +349,7 @@ export default function BalanceSheetTab() {
                 onChange={e => updateItem(setLiabilitiesList, liabilitiesList, i, 'name', e.target.value)}
                 disabled={item.id === 'pv-expenses'}
                 aria-disabled={item.id === 'pv-expenses' ? 'true' : undefined}
+                aria-label="Liability name"
                 title="Liability name"
               />
               <input
@@ -344,13 +359,14 @@ export default function BalanceSheetTab() {
                 onChange={e => updateItem(setLiabilitiesList, liabilitiesList, i, 'amount', e.target.value)}
                 disabled={item.id === 'pv-expenses'}
                 aria-disabled={item.id === 'pv-expenses' ? 'true' : undefined}
+                aria-label="Liability amount"
                 title="Liability amount"
               />
             </div>
           ))}
           <button
             onClick={addLiability}
-            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700"
+            className="bg-amber-600 text-white px-4 py-2 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
             aria-label="Add liability"
             title="Add liability"
           >
@@ -386,7 +402,7 @@ export default function BalanceSheetTab() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
         <div className="bg-white p-4 rounded-xl shadow-md">
           <h4 className="font-semibold text-slate-700 mb-2">Balance Sheet Overview</h4>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} role="img" aria-label="Balance sheet bar chart">
             <BarChart data={barData}>
               <XAxis dataKey="name" />
               <YAxis />
@@ -398,7 +414,7 @@ export default function BalanceSheetTab() {
         </div>
         <div className="bg-white p-4 rounded-xl shadow-md">
           <h4 className="font-semibold text-slate-700 mb-2">Asset Allocation</h4>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} role="img" aria-label="Asset allocation pie chart">
             <PieChart>
               <Pie data={assetPieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
                 {assetPieData.map((_, index) => (
@@ -415,7 +431,7 @@ export default function BalanceSheetTab() {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="bg-white p-4 rounded-xl shadow-md">
           <h4 className="font-semibold text-slate-700 mb-2">Liability Allocation</h4>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} role="img" aria-label="Liability allocation pie chart">
             <PieChart>
               <Pie data={liabilityPieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={80} label>
                 {liabilityPieData.map((_, index) => (
@@ -430,7 +446,7 @@ export default function BalanceSheetTab() {
 
         <div className="bg-white p-4 rounded-xl shadow-md">
           <h4 className="font-semibold text-slate-700 mb-2">Human vs Financial Capital</h4>
-          <ResponsiveContainer width="100%" height={250}>
+          <ResponsiveContainer width="100%" height={250} role="img" aria-label="Human versus financial capital chart">
             <BarChart data={humanVsFinancial}>
               <XAxis dataKey="name" />
               <YAxis />

--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -339,6 +339,7 @@ export default function ExpensesGoalsTab() {
               className="border p-2 rounded-md"
               value={e.category}
               onChange={ev => handleExpenseChange(i, 'category', ev.target.value)}
+              aria-label="Expense category"
               title="Expense category"
             >
               <option>Fixed</option>
@@ -349,6 +350,7 @@ export default function ExpensesGoalsTab() {
               className="border p-2 rounded-md"
               value={e.priority}
               onChange={ev => handleExpenseChange(i, 'priority', ev.target.value)}
+              aria-label="Expense priority"
               title="Expense priority"
             >
               <option value={1}>High</option>
@@ -357,14 +359,14 @@ export default function ExpensesGoalsTab() {
             </select>
             <button
               onClick={() => removeExpense(i)}
-              className="text-red-600 hover:text-red-800"
+              className="text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500"
               aria-label="Remove expense"
             >✖</button>
           </div>
         ))}
         <button
           onClick={addExpense}
-          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
+          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Add expense"
           title="Add expense"
         >
@@ -411,14 +413,14 @@ export default function ExpensesGoalsTab() {
             />
             <button
               onClick={() => removeGoal(i)}
-              className="text-red-600 hover:text-red-800"
+              className="text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500"
               aria-label="Remove goal"
             >✖</button>
           </div>
         ))}
         <button
           onClick={addGoal}
-          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
+          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Add goal"
           title="Add goal"
         >
@@ -506,14 +508,14 @@ export default function ExpensesGoalsTab() {
             <div className="text-right">{l.pv.toFixed(2)}</div>
             <button
               onClick={() => removeLiability(i)}
-              className="text-red-600 hover:text-red-800"
+              className="text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500"
               aria-label="Remove liability"
             >✖</button>
           </div>
         ))}
         <button
           onClick={addLiability}
-          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
+          className="mt-2 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Add liability"
           title="Add liability"
         >
@@ -524,7 +526,7 @@ export default function ExpensesGoalsTab() {
       {/* PV Summary Bar Chart */}
       <section>
         <h2 className="text-xl font-bold text-amber-700 mb-2">PV Summary</h2>
-        <ResponsiveContainer width="100%" height={300}>
+        <ResponsiveContainer width="100%" height={300} role="img" aria-label="PV summary bar chart">
           <BarChart data={pvSummaryData} margin={{ top:20, right:30, left:0, bottom:20 }}>
             <XAxis dataKey="category" />
             <YAxis tickFormatter={v =>
@@ -545,7 +547,7 @@ export default function ExpensesGoalsTab() {
         {liabilityDetails.map(l => (
           <div key={l.id} className="mb-8">
             <h3 className="text-lg font-semibold">{l.name}</h3>
-            <ResponsiveContainer width="100%" height={200}>
+            <ResponsiveContainer width="100%" height={200} role="img" aria-label="Loan amortization chart">
               <BarChart data={l.schedule}>
                 <XAxis dataKey="year" />
                 <YAxis tickFormatter={v =>
@@ -602,7 +604,7 @@ export default function ExpensesGoalsTab() {
       <div className="text-right">
         <button
           onClick={exportJSON}
-          className="mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50"
+          className="mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Export to JSON"
           title="Export to JSON"
         >

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -401,7 +401,7 @@ export default function IncomeTab() {
 
               <button
                 onClick={() => removeIncome(i)}
-                className="absolute top-2 right-2 text-red-600 hover:text-red-800"
+                className="absolute top-2 right-2 text-red-600 hover:text-red-800 focus:outline-none focus:ring-2 focus:ring-red-500"
                 aria-label="Remove income source"
               >✖</button>
             </div>
@@ -409,7 +409,7 @@ export default function IncomeTab() {
         </div>
         <button
           onClick={addIncome}
-          className="mt-4 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md"
+          className="mt-4 bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Add income source"
           title="Add income source"
         >
@@ -630,7 +630,7 @@ export default function IncomeTab() {
         <h2 className="text-lg font-bold text-amber-700 mb-2">
           Projected Income by {chartView === 'monthly' ? 'Month' : 'Year'}
         </h2>
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height="100%" role="img" aria-label="Projected income chart">
           <BarChart data={incomeData}>
             <XAxis dataKey="year" />
             <YAxis />
@@ -654,7 +654,7 @@ export default function IncomeTab() {
       <section>
         <button
           onClick={exportJSON}
-          className="bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          className="bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Export income to JSON"
           title="Export income to JSON"
         >
@@ -662,7 +662,7 @@ export default function IncomeTab() {
         </button>
         <button
           onClick={exportCSV}
-          className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Export CSV"
           title="Export CSV"
         >
@@ -670,7 +670,7 @@ export default function IncomeTab() {
         </button>
         <button
           onClick={triggerPrint}
-          className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50"
+          className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
           aria-label="Print"
           title="Print"
         >


### PR DESCRIPTION
## Summary
- add focus rings for all action buttons
- wrap balance sheet inputs with labels/aria labels and use responsive stacked layout
- label charts and form controls for improved accessibility

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684437f646a083238161e1dc96219bb7