### PR TITLE
Initialize risk score from storage

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -478,13 +478,22 @@ export function FinanceProvider({ children }) {
     const ep = localStorage.getItem('expensesPV')
     if (ep) setExpensesPV(+ep)
 
+    const rs = localStorage.getItem('riskScore')
+
     const sProf = localStorage.getItem('profile')
+    let loadedProfile = null
     if (sProf) {
       const p = safeParse(sProf, null)
       if (p) {
+        loadedProfile = p
         setProfile(p)
-        setRiskScore(calculateRiskScore(p))
       }
+    }
+
+    if (rs) {
+      setRiskScore(+rs)
+    } else if (loadedProfile) {
+      setRiskScore(calculateRiskScore(loadedProfile))
     }
 
     const sSet = localStorage.getItem('settings')


### PR DESCRIPTION
## Summary
- read riskScore from localStorage when initializing FinanceContext
- fall back to calculateRiskScore when not stored

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443c89744483238106a656c0752ce9