### PR TITLE
Add strategy utilities and context state

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react'
+import React, { useMemo, useState, useEffect } from 'react'
 import {
   BarChart,
   Bar,
@@ -31,19 +31,11 @@ export default function BalanceSheetTab() {
     discountRate,
     humanCapitalShare,
     settings,
-    riskScore,
+    strategy,
+    setStrategy,
   } = useFinance()
 
-  const [strategy, setStrategy] = useState('')
   const [expandedAssets, setExpandedAssets] = useState({})
-
-  // Initialize strategy based on risk score once on mount
-  useEffect(() => {
-    if (strategy) return
-    if (riskScore <= 6) setStrategy('Conservative')
-    else if (riskScore <= 12) setStrategy('Balanced')
-    else setStrategy('Growth')
-  }, [riskScore, strategy])
 
   const assetReturn = useMemo(() => {
     const total = assetsList.reduce((s, a) => s + Number(a.amount || 0), 0)

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react'
 import { calculatePV, frequencyToPayments } from './utils/financeUtils'
 import { riskScoreMap } from './riskScoreConfig'
+import { deriveStrategy } from './utils/strategyUtils'
 
 function safeParse(str, fallback) {
   try {
@@ -268,6 +269,22 @@ export function FinanceProvider({ children }) {
     const capAdj = p.liquidNetWorth > p.annualIncome ? 2 : 1
     return s + capAdj
   }
+
+  // === Derived strategy ===
+  const [strategy, setStrategy] = useState(() =>
+    localStorage.getItem('strategy') || ''
+  )
+
+  useEffect(() => {
+    if (!strategy) {
+      const derived = deriveStrategy(riskScore, profile.investmentHorizon)
+      setStrategy(derived)
+    }
+  }, [riskScore, profile.investmentHorizon, strategy])
+
+  useEffect(() => {
+    if (strategy) localStorage.setItem('strategy', strategy)
+  }, [strategy])
 
   // === Updaters that persist to localStorage ===
   const updateProfile = useCallback(updated => {
@@ -650,6 +667,7 @@ export function FinanceProvider({ children }) {
       // Profile & lifeExpectancy
       profile,       updateProfile,
       riskScore,
+      strategy,     setStrategy,
 
       // Settings
       settings,      updateSettings

--- a/src/__tests__/strategyUtils.test.js
+++ b/src/__tests__/strategyUtils.test.js
@@ -1,0 +1,18 @@
+import { deriveStrategy } from '../utils/strategyUtils'
+
+test('risk score boundary at 6 is Conservative', () => {
+  expect(deriveStrategy(6, '3–7 years')).toBe('Conservative')
+})
+
+test('risk score 7 yields Balanced', () => {
+  expect(deriveStrategy(7, '3–7 years')).toBe('Balanced')
+})
+
+test('risk score 12 yields Balanced', () => {
+  expect(deriveStrategy(12, '3–7 years')).toBe('Balanced')
+})
+
+test('risk score above 12 yields Growth', () => {
+  expect(deriveStrategy(13, '3–7 years')).toBe('Growth')
+})
+

--- a/src/utils/strategyUtils.js
+++ b/src/utils/strategyUtils.js
@@ -1,0 +1,15 @@
+// src/utils/strategyUtils.js
+// Utility to derive investment strategy based on risk score and horizon.
+
+export function deriveStrategy(riskScore = 0, horizon = '') {
+  let base
+  if (riskScore <= 6) base = 'Conservative'
+  else if (riskScore <= 12) base = 'Balanced'
+  else base = 'Growth'
+
+  if (horizon === '<3 years') return 'Conservative'
+  if (horizon === '>7 years') return 'Growth'
+  return base
+}
+
+export default deriveStrategy


### PR DESCRIPTION
## Summary
- implement `deriveStrategy` utility
- store strategy in `FinanceContext` and expose via context
- persist strategy to localStorage
- use context strategy in `BalanceSheetTab`
- test strategy derivation boundaries

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68443d6ade9483239547d62e1960a13b