### PR TITLE
Update README with investment strategy details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ console.log(advice.dti, advice.survival)
 
 `calcDiscretionaryAdvice` suggests low‑priority expenses to cut when the monthly surplus falls below the configured threshold. `suggestLoanStrategies` ranks liabilities by interest saved when paying them off early.
 
+## Investment Strategy
+
+The app derives a default strategy from your profile. A `riskScore` is computed using the mapping in `src/riskScoreConfig.js`. Scores up to `6` yield a **Conservative** strategy, scores from `7–12` produce **Balanced** and anything higher defaults to **Growth**. Your selected investment horizon can override this: choosing **<3 years** forces **Conservative** while **>7 years** results in **Growth**.
+
+The chosen strategy is stored in `FinanceContext` and persisted in local storage. You may pick a different option under the **Balance Sheet** tab which overrides the automatic choice and is saved for later visits.
+
 ## Manual Verification
 
 ### Verifying Charts


### PR DESCRIPTION
## Summary
- document how `riskScore` and investment horizon map to the default strategy
- explain override behaviour on the Balance Sheet tab
- mention persistence in `FinanceContext` and local storage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443ee69a90832390660f2f6bee63ea