### PR TITLE
Fix strategy autoderivation

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -276,11 +276,12 @@ export function FinanceProvider({ children }) {
   )
 
   useEffect(() => {
-    if (!strategy) {
+    const stored = localStorage.getItem('strategy')
+    if (!stored) {
       const derived = deriveStrategy(riskScore, profile.investmentHorizon)
       setStrategy(derived)
     }
-  }, [riskScore, profile.investmentHorizon, strategy])
+  }, [riskScore, profile.investmentHorizon])
 
   useEffect(() => {
     if (strategy) localStorage.setItem('strategy', strategy)

--- a/src/__tests__/financeContext.strategy.test.js
+++ b/src/__tests__/financeContext.strategy.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function StrategyDisplay() {
+  const { strategy } = useFinance()
+  return <div data-testid="strategy">{strategy}</div>
+}
+
+test('strategy is derived when risk score loads from storage', async () => {
+  localStorage.setItem('riskScore', '7')
+  localStorage.setItem('profile', JSON.stringify({ investmentHorizon: '3–7 years' }))
+  render(
+    <FinanceProvider>
+      <StrategyDisplay />
+    </FinanceProvider>
+  )
+  const out = await screen.findByTestId('strategy')
+  expect(out.textContent).toBe('Balanced')
+})


### PR DESCRIPTION
## Summary
- derive strategy when risk score or horizon updates and no stored strategy exists
- save strategy to localStorage whenever it changes
- test that strategy is derived on mount when risk score comes from storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448448cca08323b316732008619a06