### PR TITLE
Add insurance recommendations tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,14 +5,16 @@ import ExpensesGoalsTab from './ExpensesGoalsTab'
 import BalanceSheetTab from './BalanceSheetTab'
 import ProfileTab from './ProfileTab'
 import SettingsTab from './SettingsTab'
+import InsuranceTab from './InsuranceTab'
 
 
-const tabs = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile','Settings']
+const tabs = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile', 'Insurance', 'Settings']
 const components = {
   Income: IncomeTab,
   'Expenses & Goals': ExpensesGoalsTab,
   'Balance Sheet': BalanceSheetTab,
   Profile: ProfileTab,
+  Insurance: InsuranceTab,
   Settings: SettingsTab,
 }
 

--- a/src/InsuranceTab.jsx
+++ b/src/InsuranceTab.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { useFinance } from './FinanceContext'
+import { computeEmergencyFund, computeLifeCover } from './utils/insuranceUtils'
+import { formatCurrency } from './utils/formatters'
+
+export default function InsuranceTab() {
+  const { monthlyExpense, profile, settings } = useFinance()
+
+  const emergencyAmount = computeEmergencyFund(
+    monthlyExpense,
+    profile.numDependents
+  )
+  const emergencyMonths =
+    monthlyExpense > 0 ? Math.round(emergencyAmount / monthlyExpense) : 0
+
+  const lifeCover = computeLifeCover(
+    profile.annualIncome,
+    profile.numDependents,
+    (profile.maritalStatus || 'single').toLowerCase()
+  )
+
+  return (
+    <div className="space-y-6 p-6">
+      <h2 className="text-2xl font-bold text-amber-700">
+        Insurance Recommendations
+      </h2>
+      <div className="space-y-2 text-slate-700">
+        <p>
+          Emergency Fund:&nbsp;
+          <strong>{emergencyMonths}</strong> months (~
+          <strong>
+            {formatCurrency(
+              emergencyAmount,
+              settings.locale,
+              settings.currency
+            )}
+          </strong>
+          )
+        </p>
+        <p>
+          Recommended Life Cover:&nbsp;
+          <strong>
+            {formatCurrency(lifeCover, settings.locale, settings.currency)}
+          </strong>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/__tests__/insuranceTab.integration.test.js
+++ b/src/__tests__/insuranceTab.integration.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import InsuranceTab from '../InsuranceTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+test('shows emergency fund months and life cover amount', () => {
+  localStorage.setItem('monthlyExpense', '2000')
+  localStorage.setItem(
+    'expensesList',
+    JSON.stringify([{ name: 'Rent', amount: 2000, paymentsPerYear: 12 }])
+  )
+  localStorage.setItem(
+    'profile',
+    JSON.stringify({ numDependents: 2, annualIncome: 60000, maritalStatus: 'Married' })
+  )
+
+  render(
+    <FinanceProvider>
+      <InsuranceTab />
+    </FinanceProvider>
+  )
+
+  expect(screen.getByText('Insurance Recommendations')).toBeInTheDocument()
+  expect(screen.getByText(/Emergency Fund:/)).toHaveTextContent('5')
+  expect(screen.getByText(/Life Cover/)).toHaveTextContent('720,000')
+})


### PR DESCRIPTION
## Summary
- implement `InsuranceTab` to display emergency fund and life cover suggestions
- expose new tab from `App.jsx`
- test `InsuranceTab`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68448e19cbb8832381560d936c2702ae