### PR TITLE
Add profile data to export files

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -9,6 +9,7 @@ import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import generateLoanAdvice from './utils/loanAdvisoryEngine'
 import AdviceDashboard from './AdviceDashboard'
 import calcDiscretionaryAdvice from './utils/discretionaryUtils'
+import { buildPlanJSON, buildPlanCSV } from './utils/exportHelpers'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend
@@ -256,23 +257,33 @@ export default function ExpensesGoalsTab() {
 
   // --- Export JSON ---
   const exportJSON = () => {
-    const payload = {
-      generatedAt: new Date().toISOString(),
+    const payload = buildPlanJSON(
       profile,
-      assumptions: { discountRate, lifeYears },
-      expenses:      expensesList, pvExpenses: pvExpensesLife,
-      goals:         goalsList,    pvGoals,
-      liabilities:   liabilityDetails.map(l => {
-        const { schedule: _unused, ...rest } = l;
-        return rest;
-      }),
-      totalLiabilitiesPV, totalRequired
-    }
+      discountRate,
+      lifeYears,
+      expensesList,
+      pvExpensesLife,
+      goalsList,
+      pvGoals,
+      liabilityDetails,
+      totalLiabilitiesPV,
+      totalRequired
+    )
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
     const url  = URL.createObjectURL(blob)
     const a    = document.createElement('a')
     a.href     = url
     a.download = 'financial-plan.json'
+    a.click()
+  }
+
+  const exportCSV = () => {
+    const csv = buildPlanCSV(profile, pvSummaryData)
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'financial-plan.csv'
     a.click()
   }
 
@@ -609,6 +620,14 @@ export default function ExpensesGoalsTab() {
           title="Export to JSON"
         >
           📁 Export to JSON
+        </button>
+        <button
+          onClick={exportCSV}
+          className="ml-2 mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Export to CSV"
+          title="Export to CSV"
+        >
+          📊 Export to CSV
         </button>
       </div>
     </div>

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -12,7 +12,7 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { useFinance } from './FinanceContext';
 import { calculatePV } from './utils/financeUtils';
-import { buildCSV } from './utils/csvUtils'
+import { buildIncomeJSON, buildIncomeCSV } from './utils/exportHelpers'
 import {
   calculateNominalSurvival,
   calculatePVSurvival,
@@ -270,11 +270,16 @@ export default function IncomeTab() {
 
   // --- Export JSON payload ---
   const exportJSON = () => {
-    const payload = {
-      startYear, incomeSources,
-      assumptions: { discountRate, years, monthlyExpense },
-      pvPerStream, totalPV,
-    };
+    const payload = buildIncomeJSON(
+      profile,
+      startYear,
+      incomeSources,
+      discountRate,
+      years,
+      monthlyExpense,
+      pvPerStream,
+      totalPV
+    )
     const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -288,7 +293,7 @@ export default function IncomeTab() {
     const rows = incomeData.map(row =>
       columns.map(col => (col === 'Period' ? row.year : row[col]))
     )
-    const csv = buildCSV(columns, rows)
+    const csv = buildIncomeCSV(profile, columns, rows)
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/src/__tests__/exportHelpers.test.js
+++ b/src/__tests__/exportHelpers.test.js
@@ -1,0 +1,33 @@
+import { buildIncomeJSON, buildIncomeCSV, buildPlanJSON, buildPlanCSV } from '../utils/exportHelpers'
+
+test('income JSON payload contains profile fields', () => {
+  const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
+  const payload = buildIncomeJSON(profile, 2024, [], 5, 10, 1000, [], 0)
+  expect(payload.profile.email).toBe('test@example.com')
+  expect(payload.profile.phone).toBe('555-1234')
+  expect(payload.profile.residentialAddress).toBe('123 St')
+})
+
+test('income CSV includes profile header', () => {
+  const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
+  const csv = buildIncomeCSV(profile, ['Col'], [[1]])
+  expect(csv).toContain('test@example.com')
+  expect(csv).toContain('555-1234')
+  expect(csv).toContain('123 St')
+})
+
+test('plan JSON payload contains profile fields', () => {
+  const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
+  const payload = buildPlanJSON(profile, 5, 20, [], 0, [], 0, [], 0, 0)
+  expect(payload.profile.email).toBe('test@example.com')
+  expect(payload.profile.phone).toBe('555-1234')
+  expect(payload.profile.residentialAddress).toBe('123 St')
+})
+
+test('plan CSV includes profile header', () => {
+  const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
+  const csv = buildPlanCSV(profile, [{ category:'Expenses', value:100 }])
+  expect(csv).toContain('test@example.com')
+  expect(csv).toContain('555-1234')
+  expect(csv).toContain('123 St')
+})

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -1,0 +1,57 @@
+import { buildCSV, quoteCSV } from './csvUtils'
+
+export function buildIncomeJSON(profile, startYear, incomeSources, discountRate, years, monthlyExpense, pvPerStream, totalPV) {
+  return {
+    generatedAt: new Date().toISOString(),
+    profile,
+    startYear,
+    incomeSources,
+    assumptions: { discountRate, years, monthlyExpense },
+    pvPerStream,
+    totalPV,
+  }
+}
+
+export function buildIncomeCSV(profile, columns = [], rows = []) {
+  const headerRows = [
+    ['Name', profile.name || ''],
+    ['Email', profile.email || ''],
+    ['Phone', profile.phone || ''],
+    ['Address', profile.residentialAddress || ''],
+  ]
+  const header = headerRows.map(r => r.map(quoteCSV).join(',')).join('\n')
+  const data = buildCSV(columns, rows)
+  return header + '\n' + data
+}
+
+export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pvExpenses, goalsList, pvGoals, liabilities, totalLiabilitiesPV, totalRequired) {
+  return {
+    generatedAt: new Date().toISOString(),
+    profile,
+    assumptions: { discountRate, lifeYears },
+    expenses: expensesList,
+    pvExpenses,
+    goals: goalsList,
+    pvGoals,
+    liabilities: liabilities.map(l => {
+      const { schedule, ...rest } = l
+      return rest
+    }),
+    totalLiabilitiesPV,
+    totalRequired,
+  }
+}
+
+export function buildPlanCSV(profile, pvSummaryData = []) {
+  const headerRows = [
+    ['Name', profile.name || ''],
+    ['Email', profile.email || ''],
+    ['Phone', profile.phone || ''],
+    ['Address', profile.residentialAddress || ''],
+  ]
+  const header = headerRows.map(r => r.map(quoteCSV).join(',')).join('\n')
+  const columns = ['Category', 'Value']
+  const rows = pvSummaryData.map(d => [d.category, d.value])
+  const data = buildCSV(columns, rows)
+  return header + '\n' + data
+}


### PR DESCRIPTION
## Summary
- expose utilities for CSV/JSON export with profile headers
- embed profile info in IncomeTab exports
- add CSV export to ExpensesGoalsTab and include profile data
- test export helpers ensure profile details included

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448f8536b88323b3607206cbcea274