### PR TITLE
Add profile submission to API

### DIFF
--- a/src/ExpensesGoalsTab.jsx
+++ b/src/ExpensesGoalsTab.jsx
@@ -9,7 +9,7 @@ import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import generateLoanAdvice from './utils/loanAdvisoryEngine'
 import AdviceDashboard from './AdviceDashboard'
 import calcDiscretionaryAdvice from './utils/discretionaryUtils'
-import { buildPlanJSON, buildPlanCSV } from './utils/exportHelpers'
+import { buildPlanJSON, buildPlanCSV, submitProfile } from './utils/exportHelpers'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend
@@ -285,6 +285,22 @@ export default function ExpensesGoalsTab() {
     a.href = url
     a.download = 'financial-plan.csv'
     a.click()
+  }
+
+  const submitToAPI = () => {
+    const payload = buildPlanJSON(
+      profile,
+      discountRate,
+      lifeYears,
+      expensesList,
+      pvExpensesLife,
+      goalsList,
+      pvGoals,
+      liabilityDetails,
+      totalLiabilitiesPV,
+      totalRequired
+    )
+    submitProfile(payload, settings)
   }
 
   const COLORS = ['#fbbf24','#f59e0b','#fcd34d','#fde68a','#eab308']
@@ -628,6 +644,14 @@ export default function ExpensesGoalsTab() {
           title="Export to CSV"
         >
           📊 Export to CSV
+        </button>
+        <button
+          onClick={submitToAPI}
+          className="ml-2 mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Submit plan to API"
+          title="Submit plan to API"
+        >
+          🚀 Submit to API
         </button>
       </div>
     </div>

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -12,7 +12,7 @@
 import React, { useMemo, useEffect, useState } from 'react';
 import { useFinance } from './FinanceContext';
 import { calculatePV } from './utils/financeUtils';
-import { buildIncomeJSON, buildIncomeCSV } from './utils/exportHelpers'
+import { buildIncomeJSON, buildIncomeCSV, submitProfile } from './utils/exportHelpers'
 import {
   calculateNominalSurvival,
   calculatePVSurvival,
@@ -300,6 +300,20 @@ export default function IncomeTab() {
     a.href = url;
     a.download = 'income-data.csv';
     a.click();
+  };
+
+  const submitToAPI = () => {
+    const payload = buildIncomeJSON(
+      profile,
+      startYear,
+      incomeSources,
+      discountRate,
+      years,
+      monthlyExpense,
+      pvPerStream,
+      totalPV
+    )
+    submitProfile(payload, settings)
   };
 
   const triggerPrint = () => window.print();
@@ -672,6 +686,14 @@ export default function IncomeTab() {
           title="Export CSV"
         >
           📊 Export CSV
+        </button>
+        <button
+          onClick={submitToAPI}
+          className="ml-2 bg-white border border-amber-600 text-amber-700 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Submit income to API"
+          title="Submit income to API"
+        >
+          🚀 Submit to API
         </button>
         <button
           onClick={triggerPrint}

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -55,3 +55,17 @@ export function buildPlanCSV(profile, pvSummaryData = []) {
   const data = buildCSV(columns, rows)
   return header + '\n' + data
 }
+
+export async function submitProfile(payload = {}, settings = {}) {
+  if (!settings.apiEndpoint) return
+  if (typeof fetch !== 'function') return
+  try {
+    await fetch(settings.apiEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+  } catch (err) {
+    console.error('Failed to submit profile', err)
+  }
+}


### PR DESCRIPTION
## Summary
- add `submitProfile` helper that posts JSON to configured API endpoint
- expose API submission buttons for income and plan exports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684490acc6fc832395249fdf3d9337fe