### PR TITLE
Add tax utils and dynamic currency default

### DIFF
--- a/src/utils/taxUtils.js
+++ b/src/utils/taxUtils.js
@@ -1,0 +1,21 @@
+// src/utils/taxUtils.js
+// Stub utilities for tax calculations.
+
+/**
+ * Derive tax rules based on nationality and tax residence.
+ * Placeholder implementation returns generic rules.
+ *
+ * @param {string} nationality - Country of nationality.
+ * @param {string} taxResidence - Country of tax residence.
+ * @returns {Object} Derived tax rule set.
+ */
+export function deriveTaxRules(nationality = '', taxResidence = '') {
+  void nationality; // unused until implemented
+  void taxResidence;
+  return {
+    brackets: [],
+    notes: 'Tax rules not implemented yet'
+  };
+}
+
+export default deriveTaxRules;


### PR DESCRIPTION
## Summary
- stub `deriveTaxRules` utility
- choose default currency from nationality when settings are empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684491e3f41883239b5e9b412e63abda