### PR TITLE
Add FIXME markers for unused profile fields

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,11 @@ export default [
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      // Warn on FIXME/TODO comments so they are reviewed before release
+      'no-warning-comments': [
+        'warn',
+        { terms: ['todo', 'fixme'], location: 'anywhere' },
+      ],
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -216,20 +216,20 @@ export function FinanceProvider({ children }) {
   const [profile, setProfile] = useState(() => {
     const s = localStorage.getItem('profile')
     const defaults = {
-      name: '', // TODO: unused - pending integration
-      email: '', // TODO: unused - pending integration
-      phone: '', // TODO: unused - pending integration
+      name: '', // FIXME: unused - pending integration
+      email: '', // FIXME: unused - pending integration
+      phone: '', // FIXME: unused - pending integration
       age: 30,
-      maritalStatus: '', // TODO: unused - pending integration
-      numDependents: 0, // TODO: unused - pending integration
-      residentialAddress: '', // TODO: unused - pending integration
-      nationality: '', // TODO: unused - pending integration
-      idNumber: '', // TODO: unused - pending integration
-      taxResidence: '', // TODO: unused - pending integration
-      employmentStatus: '', // TODO: unused - pending integration
+      maritalStatus: '', // FIXME: unused - pending integration
+      numDependents: 0, // FIXME: unused - pending integration
+      residentialAddress: '', // FIXME: unused - pending integration
+      nationality: '', // FIXME: unused - pending integration
+      idNumber: '', // FIXME: unused - pending integration
+      taxResidence: '', // FIXME: unused - pending integration
+      employmentStatus: '', // FIXME: unused - pending integration
       annualIncome: 0,
       liquidNetWorth: 0,
-      sourceOfFunds: '', // TODO: unused - pending integration
+      sourceOfFunds: '', // FIXME: unused - pending integration
       investmentKnowledge: '',
       lossResponse: '',
       investmentHorizon: '',

--- a/src/ProfileTab.jsx
+++ b/src/ProfileTab.jsx
@@ -55,13 +55,13 @@ export default function ProfileTab() {
             Personal & KYC Information
           </h3>
           {[
-            ['Full Name', 'name', 'text'], // TODO: unused - pending integration
-            ['Email Address', 'email', 'email'], // TODO: unused - pending integration
-            ['Phone Number', 'phone', 'tel'], // TODO: unused - pending integration
+            ['Full Name', 'name', 'text'], // FIXME: unused - pending integration
+            ['Email Address', 'email', 'email'], // FIXME: unused - pending integration
+            ['Phone Number', 'phone', 'tel'], // FIXME: unused - pending integration
             ['Age', 'age', 'number'],
             ['Life Expectancy', 'lifeExpectancy', 'number'],
-            ['Marital Status', 'maritalStatus', 'select', ['', 'Single', 'Married', 'Divorced', 'Widowed']], // TODO: unused - pending integration
-            ['Dependents', 'numDependents', 'number'] // TODO: unused - pending integration
+            ['Marital Status', 'maritalStatus', 'select', ['', 'Single', 'Married', 'Divorced', 'Widowed']], // FIXME: unused - pending integration
+            ['Dependents', 'numDependents', 'number'] // FIXME: unused - pending integration
           ].map(([label, field, type, options]) => (
             <label key={field} className="block">
               <span className="text-sm text-slate-600">{label}</span>
@@ -99,11 +99,11 @@ export default function ProfileTab() {
           )}
 
           {[
-            ['Residential Address', 'residentialAddress'], // TODO: unused - pending integration
-            ['Nationality', 'nationality'], // TODO: unused - pending integration
-            ['ID / Passport #', 'idNumber'], // TODO: unused - pending integration
-            ['Tax Residence', 'taxResidence'], // TODO: unused - pending integration
-            ['Employment Status', 'employmentStatus'] // TODO: unused - pending integration
+            ['Residential Address', 'residentialAddress'], // FIXME: unused - pending integration
+            ['Nationality', 'nationality'], // FIXME: unused - pending integration
+            ['ID / Passport #', 'idNumber'], // FIXME: unused - pending integration
+            ['Tax Residence', 'taxResidence'], // FIXME: unused - pending integration
+            ['Employment Status', 'employmentStatus'] // FIXME: unused - pending integration
           ].map(([label, field]) => (
             <label key={field} className="block">
               <span className="text-sm text-slate-600">{label}</span>
@@ -134,7 +134,7 @@ export default function ProfileTab() {
           ))}
 
           <label className="block">
-            <span className="text-sm text-slate-600">Source of Funds</span>{/* TODO: unused - pending integration */}
+            <span className="text-sm text-slate-600">Source of Funds</span>{/* FIXME: unused - pending integration */}
             <textarea
               value={form.sourceOfFunds}
               onChange={e => handleChange('sourceOfFunds', e.target.value)}

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -34,7 +34,7 @@ export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pv
     goals: goalsList,
     pvGoals,
     liabilities: liabilities.map(l => {
-      const { schedule, ...rest } = l
+      const { schedule: _schedule, ...rest } = l
       return rest
     }),
     totalLiabilitiesPV,


### PR DESCRIPTION
## Summary
- flag unused profile attributes in ProfileTab and FinanceContext
- warn about TODO/FIXME comments via ESLint
- fix lint warning in exportHelpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68449345e1ac8323a84dd208b93698e7