### PR TITLE
Add App-level error boundary

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
   transform: {
     '^.+\\.[jt]sx?$': 'babel-jest'
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(react-error-boundary)/)'
+  ],
   moduleFileExtensions: ['js', 'jsx', 'json'],
   setupFilesAfterEnv: ['@testing-library/jest-dom']
 }

--- a/src/AppErrorBoundary.jsx
+++ b/src/AppErrorBoundary.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { ErrorBoundary } from 'react-error-boundary'
+
+function Fallback() {
+  return (
+    <div className="p-4 text-red-600">
+      Oops—something went wrong. Please refresh or try a different tab.
+    </div>
+  )
+}
+
+export default function AppErrorBoundary({ children }) {
+  return (
+    <ErrorBoundary FallbackComponent={Fallback}>
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/src/__tests__/appErrorBoundary.test.js
+++ b/src/__tests__/appErrorBoundary.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import AppErrorBoundary from '../AppErrorBoundary'
+
+function Boom() {
+  throw new Error('Boom')
+}
+
+test('boundary renders fallback when child throws', () => {
+  render(
+    <AppErrorBoundary>
+      <Boom />
+    </AppErrorBoundary>
+  )
+  expect(
+    screen.getByText(/something went wrong/i)
+  ).toBeInTheDocument()
+})

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { FinanceProvider } from './FinanceContext.jsx'
+import AppErrorBoundary from './AppErrorBoundary.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <FinanceProvider>
-      <App />
+      <AppErrorBoundary>
+        <App />
+      </AppErrorBoundary>
     </FinanceProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add `AppErrorBoundary` component powered by `react-error-boundary`
- wrap `<App>` in the new boundary
- transform `react-error-boundary` in Jest
- test that the boundary renders its fallback when a child throws

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68449b4866d0832390cd3f57b0020abe