### PR TITLE
Lazy load tabs and add spinner

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 // src/App.jsx
-import React, { useState } from 'react'
-import IncomeTab from './IncomeTab'
-import ExpensesGoalsTab from './ExpensesGoalsTab'
-import BalanceSheetTab from './BalanceSheetTab'
-import ProfileTab from './ProfileTab'
-import SettingsTab from './SettingsTab'
-import InsuranceTab from './InsuranceTab'
+import React, { Suspense, useState } from 'react'
+import Spinner from './Spinner.jsx'
+
+const IncomeTab = React.lazy(() => import('./IncomeTab.jsx'))
+const ExpensesGoalsTab = React.lazy(() => import('./ExpensesGoalsTab.jsx'))
+const BalanceSheetTab = React.lazy(() => import('./BalanceSheetTab.jsx'))
+const ProfileTab = React.lazy(() => import('./ProfileTab.jsx'))
+const SettingsTab = React.lazy(() => import('./SettingsTab.jsx'))
+const InsuranceTab = React.lazy(() => import('./InsuranceTab.jsx'))
 
 
 const tabs = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile', 'Insurance', 'Settings']
@@ -49,7 +51,9 @@ export default function App() {
       </nav>
 
       <div className="bg-white p-4 rounded shadow min-h-[300px]">
-        <Active />
+        <Suspense fallback={<Spinner />}>
+          <Active />
+        </Suspense>
       </div>
     </div>
   )

--- a/src/Spinner.jsx
+++ b/src/Spinner.jsx
@@ -1,0 +1,10 @@
+// src/Spinner.jsx
+import React from 'react'
+
+export default function Spinner() {
+  return (
+    <div className="flex justify-center items-center py-6" role="status">
+      <div className="h-6 w-6 border-4 border-amber-700 border-t-transparent rounded-full animate-spin" />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- lazily load tabs in App.jsx
- display a spinner while loading tabs
- implement a simple Spinner component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68449ea438d48323a52c6c2e810cd2e7