### PR TITLE
Add tests for storage events and PV recalculation

### DIFF
--- a/src/__tests__/appSuspense.test.js
+++ b/src/__tests__/appSuspense.test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App'
+import { FinanceProvider } from '../FinanceContext'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('lazy loaded tabs render with Suspense fallback', async () => {
+  render(
+    <FinanceProvider>
+      <App />
+    </FinanceProvider>
+  )
+  // default tab should load
+  await screen.findByText(/Income Sources/i)
+
+  fireEvent.click(screen.getByRole('tab', { name: /Settings/i }))
+
+  // Spinner should appear while loading
+  expect(screen.getByRole('status')).toBeInTheDocument()
+
+  const settingsHeading = await screen.findByText(/Global Settings/i)
+  expect(settingsHeading).toBeInTheDocument()
+  // spinner disappears after load
+  expect(screen.queryByRole('status')).toBeNull()
+})

--- a/src/__tests__/financeContext.pvMetricsRecompute.test.js
+++ b/src/__tests__/financeContext.pvMetricsRecompute.test.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function MetricsTest() {
+  const {
+    monthlyPVExpense,
+    pvHigh,
+    updateSettings,
+    settings,
+  } = useFinance()
+
+  const handleUpdate = () => {
+    updateSettings({ ...settings, discountRate: 10 })
+  }
+
+  return (
+    <div>
+      <div data-testid="month">{monthlyPVExpense}</div>
+      <div data-testid="high">{pvHigh}</div>
+      <button onClick={handleUpdate} data-testid="update">Update</button>
+    </div>
+  )
+}
+
+test('expense PV metrics update after settings change', async () => {
+  localStorage.setItem(
+    'expensesList',
+    JSON.stringify([
+      { name: 'Rent', amount: 1200, paymentsPerYear: 12, growth: 0, priority: 1 }
+    ])
+  )
+  render(
+    <FinanceProvider>
+      <MetricsTest />
+    </FinanceProvider>
+  )
+
+  await waitFor(() =>
+    Number(screen.getByTestId('high').textContent) > 0
+  )
+
+  const monthBefore = Number(screen.getByTestId('month').textContent)
+  const highBefore = Number(screen.getByTestId('high').textContent)
+
+  fireEvent.click(screen.getByTestId('update'))
+
+  await waitFor(() =>
+    Number(screen.getByTestId('month').textContent) !== monthBefore ||
+    Number(screen.getByTestId('high').textContent) !== highBefore
+  )
+})

--- a/src/__tests__/storage.test.js
+++ b/src/__tests__/storage.test.js
@@ -22,4 +22,18 @@ describe('storage helpers', () => {
     storage.set('b', 'y')
     expect(events).toEqual(['x', null])
   })
+
+  test('multiple subscribers receive updates', () => {
+    const first = []
+    const second = []
+    const unsub1 = storage.subscribe('c', v => first.push(v))
+    const unsub2 = storage.subscribe('c', v => second.push(v))
+    storage.set('c', '1')
+    unsub1()
+    storage.set('c', '2')
+    storage.remove('c')
+    unsub2()
+    expect(first).toEqual(['1'])
+    expect(second).toEqual(['1', '2', null])
+  })
 })


### PR DESCRIPTION
## Summary
- extend storage service unit tests for multiple subscribers
- add FinanceContext tests ensuring PV metrics update when settings change
- verify lazy loaded tabs still render via React.Suspense

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844a05acee4832386cd6075299d5217