### PR TITLE
Support start/end year for incomes

### DIFF
--- a/src/__tests__/incomeDuration.test.js
+++ b/src/__tests__/incomeDuration.test.js
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+global.ResizeObserver = class { observe() {}; unobserve() {}; disconnect() {} }
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function PVDisplay({ years }) {
+  const { incomePV, setYears } = useFinance()
+  useEffect(() => { setYears(years) }, [years, setYears])
+  return <div data-testid="pv">{incomePV}</div>
+}
+
+test('finite income stream stops at endYear', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ inflationRate: 0 }))
+  localStorage.setItem('incomeStartYear', String(current))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Contract', type: 'Employment', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current, endYear: current + 1 }
+  ]))
+  render(
+    <FinanceProvider>
+      <PVDisplay years={5} />
+    </FinanceProvider>
+  )
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(2000)
+})
+
+test('income without endYear persists through horizon', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ inflationRate: 0 }))
+  localStorage.setItem('incomeStartYear', String(current))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Job', type: 'Employment', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current }
+  ]))
+  render(
+    <FinanceProvider>
+      <PVDisplay years={5} />
+    </FinanceProvider>
+  )
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(5000)
+})


### PR DESCRIPTION
## Summary
- add `startYear` and `endYear` fields for income sources
- migrate saved income records when loading
- update PV and chart calculations to respect duration
- expose start/end year pickers in UI
- test finite vs perpetual income streams

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844a2f561248323b73e4856d61457d7