### PR TITLE
Fix PV growth calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This ensures that ESLint and Jest are available locally.
 
 Application settings are stored in local storage and can be modified under the **Settings** tab.  Available keys include:
 
-- `inflationRate` – annual inflation assumption used in PV calculations
+- `inflationRate` – stored for reference only; PV calculations use nominal growth
 - `expectedReturn` – expected yearly portfolio return
 - `currency` – default ISO currency code
 - `locale` – locale for number formatting

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -448,12 +448,11 @@ export function FinanceProvider({ children }) {
 
   const incomePvValue = useMemo(() => {
     const rate = settings.discountRate ?? discountRate
-    const inflation = settings.inflationRate ?? 0
     const planStart = startYear
     const planEnd = startYear + years - 1
     return incomeSources.reduce((sum, src) => {
       const afterTaxAmt = src.amount * (1 - (src.taxRate || 0) / 100)
-      const growth = (src.growth || 0) - inflation
+      const growth = src.growth || 0
       const srcStart = Math.max(src.startYear ?? planStart, planStart)
       const srcEnd = src.endYear ?? planEnd
       const effectiveEnd = Math.min(srcEnd, planEnd)
@@ -486,9 +485,8 @@ export function FinanceProvider({ children }) {
     let medium = 0
     let low = 0
     const rate = settings.discountRate ?? discountRate
-    const inflation = settings.inflationRate ?? 0
     const totalPv = expensesList.reduce((sum, exp) => {
-      const growth = (exp.growth || 0) - inflation
+      const growth = exp.growth || 0
       const pv = calculatePV(
         exp.amount,
         exp.paymentsPerYear,

--- a/src/__tests__/pvNominalGrowth.test.js
+++ b/src/__tests__/pvNominalGrowth.test.js
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import { calculatePV } from '../utils/financeUtils'
+
+global.ResizeObserver = class { observe() {}; unobserve() {}; disconnect() {} }
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function IncomePV({ years }) {
+  const { incomePV, setYears } = useFinance()
+  useEffect(() => { setYears(years) }, [years, setYears])
+  return <div data-testid="pv">{incomePV}</div>
+}
+
+test('income PV uses nominal growth rate', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('incomeStartYear', String(current))
+  localStorage.setItem('settings', JSON.stringify({ discountRate: 10, inflationRate: 5 }))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Job', type: 'Salary', amount: 1000, frequency: 1, growth: 5, taxRate: 0 }
+  ]))
+
+  render(
+    <FinanceProvider>
+      <IncomePV years={5} />
+    </FinanceProvider>
+  )
+
+  const expected = calculatePV(1000, 1, 5, 10, 5)
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(expected)
+})
+
+function ExpensePV({ years }) {
+  const { expensesPV, setYears } = useFinance()
+  useEffect(() => { setYears(years) }, [years, setYears])
+  return <div data-testid="pv">{expensesPV}</div>
+}
+
+test('expense PV uses nominal growth rate', () => {
+  localStorage.setItem('settings', JSON.stringify({ discountRate: 8, inflationRate: 3 }))
+  localStorage.setItem('expensesList', JSON.stringify([
+    { name: 'Rent', amount: 500, paymentsPerYear: 1, growth: 4, priority: 1 }
+  ]))
+
+  render(
+    <FinanceProvider>
+      <ExpensePV years={5} />
+    </FinanceProvider>
+  )
+
+  const expected = calculatePV(500, 1, 4, 8, 5)
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(expected)
+})


### PR DESCRIPTION
## Summary
- stop subtracting inflation from growth when computing income and expense PV
- clarify inflation rate usage in README
- test that PV calculations ignore inflation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a48f5f3c8323b4e070446a5fb7b2