### PR TITLE
Add adequacy engine and selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-error-boundary": "^6.0.0",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "reselect": "^4.1.8"
       },
       "devDependencies": {
         "@babel/core": "^7.27.3",
@@ -11595,6 +11596,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-error-boundary": "^6.0.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "reselect": "^4.1.8"
   },
   "devDependencies": {
     "@babel/core": "^7.27.3",

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -9,6 +9,12 @@ import React, {
   useMemo,
 } from 'react'
 import { calculatePV, frequencyToPayments } from './utils/financeUtils'
+import {
+  selectAnnualIncome,
+  selectAnnualOutflow,
+  selectDiscountedNet,
+  selectCumulativePV
+} from './selectors'
 import { riskScoreMap } from './riskScoreConfig'
 import { deriveStrategy } from './utils/strategyUtils'
 import storage from './utils/storage'
@@ -446,6 +452,55 @@ export function FinanceProvider({ children }) {
     storage.set('monthlySurplusNominal', surplus.toString())
   }, [incomeSources, monthlyExpense])
 
+  const annualIncome = useMemo(
+    () =>
+      selectAnnualIncome({
+        incomeSources,
+        startYear,
+        years,
+        settings
+      }),
+    [incomeSources, startYear, years, settings, profile]
+  )
+
+  const annualOutflow = useMemo(
+    () =>
+      selectAnnualOutflow({
+        expensesList,
+        goalsList,
+        startYear,
+        years,
+        settings
+      }),
+    [expensesList, goalsList, startYear, years, settings, profile]
+  )
+
+  const discountedNet = useMemo(
+    () =>
+      selectDiscountedNet({
+        incomeSources,
+        expensesList,
+        goalsList,
+        startYear,
+        years,
+        settings
+      }),
+    [incomeSources, expensesList, goalsList, startYear, years, settings, profile]
+  )
+
+  const cumulativePV = useMemo(
+    () =>
+      selectCumulativePV({
+        incomeSources,
+        expensesList,
+        goalsList,
+        startYear,
+        years,
+        settings
+      }),
+    [incomeSources, expensesList, goalsList, startYear, years, settings, profile]
+  )
+
   const incomePvValue = useMemo(() => {
     const rate = settings.discountRate ?? discountRate
     const planStart = startYear
@@ -524,6 +579,8 @@ export function FinanceProvider({ children }) {
     storage.set('pvMedium', medium.toString())
     setPvLow(low)
     storage.set('pvLow', low.toString())
+    setExpensesPV(totalPv)
+    storage.set('expensesPV', totalPv.toString())
     setPvExpenses(totalPv)
     storage.set('pvExpenses', totalPv.toString())
     setMonthlyPVExpense(avgMonthly)
@@ -741,6 +798,10 @@ export function FinanceProvider({ children }) {
       monthlyPVLow,
       monthlySurplusNominal,
       monthlyIncomeNominal,
+      annualIncome,
+      annualOutflow,
+      discountedNet,
+      cumulativePV,
       netWorth,
       debtToAssetRatio,
       humanCapitalShare,

--- a/src/__tests__/adequacyEngine.test.js
+++ b/src/__tests__/adequacyEngine.test.js
@@ -1,0 +1,30 @@
+import { computeSurvivalMonths, computeFundingGaps } from '../engines/adequacy'
+import {
+  calculateNominalSurvival,
+  calculatePVSurvival,
+  calculatePVObligationSurvival
+} from '../utils/survivalMetrics'
+
+test('computeSurvivalMonths delegates based on method', () => {
+  const pv = 120000
+  const rate = 6
+  const years = 10
+  const exp = 1000
+
+  expect(
+    computeSurvivalMonths(pv, exp, { discountRate: rate, horizonYears: years })
+  ).toBe(calculatePVSurvival(pv, rate, exp, years))
+
+  expect(
+    computeSurvivalMonths(pv, exp, { discountRate: rate, horizonYears: years, method: 'nominal' })
+  ).toBe(calculateNominalSurvival(pv, rate, years, exp))
+
+  expect(
+    computeSurvivalMonths(pv, exp, { discountRate: rate, method: 'obligation' })
+  ).toBe(calculatePVObligationSurvival(pv, rate, exp))
+})
+
+test('computeFundingGaps returns deficits', () => {
+  const gaps = computeFundingGaps([5, -2, 3, -1])
+  expect(gaps).toEqual([0, 2, 0, 1])
+})

--- a/src/__tests__/selectors.test.js
+++ b/src/__tests__/selectors.test.js
@@ -1,0 +1,45 @@
+import {
+  selectAnnualIncome,
+  selectAnnualOutflow,
+  selectDiscountedNet,
+  selectCumulativePV
+} from '../selectors'
+
+const baseState = {
+  startYear: 2024,
+  years: 2,
+  settings: { discountRate: 10 },
+  incomeSources: [
+    { amount: 1000, frequency: 12, growth: 0, taxRate: 0 }
+  ],
+  expensesList: [
+    { amount: 500, paymentsPerYear: 12, growth: 0 }
+  ],
+  goalsList: [
+    { amount: 1200, targetYear: 2025 }
+  ]
+}
+
+test('annual income sums per year', () => {
+  const income = selectAnnualIncome(baseState)
+  expect(income).toEqual([12000, 12000])
+})
+
+test('annual outflow includes goals', () => {
+  const out = selectAnnualOutflow(baseState)
+  expect(out).toEqual([6000, 7200])
+})
+
+test('discounted net uses discount rate', () => {
+  const net = selectDiscountedNet(baseState)
+  expect(net[0]).toBeCloseTo(6000 / 1.1)
+  expect(net[1]).toBeCloseTo(4800 / (1.1 ** 2))
+})
+
+test('cumulative pv sums discounted net', () => {
+  const cum = selectCumulativePV(baseState)
+  const first = 6000 / 1.1
+  const second = first + 4800 / (1.1 ** 2)
+  expect(cum[0]).toBeCloseTo(first)
+  expect(cum[1]).toBeCloseTo(second)
+})

--- a/src/engines/adequacy.js
+++ b/src/engines/adequacy.js
@@ -1,0 +1,26 @@
+import {
+  calculateNominalSurvival,
+  calculatePVSurvival,
+  calculatePVObligationSurvival
+} from '../utils/survivalMetrics'
+
+export function computeSurvivalMonths(pvIncome = 0, monthlyOutflow = 0, options = {}) {
+  const { discountRate = 0, horizonYears = 1, method = 'pv' } = options
+  if (method === 'nominal') {
+    return calculateNominalSurvival(pvIncome, discountRate, horizonYears, monthlyOutflow)
+  }
+  if (method === 'obligation') {
+    return calculatePVObligationSurvival(pvIncome, discountRate, monthlyOutflow)
+  }
+  return calculatePVSurvival(pvIncome, discountRate, monthlyOutflow, horizonYears)
+}
+
+export function computeFundingGaps(cumulativePV = []) {
+  if (!Array.isArray(cumulativePV)) return []
+  return cumulativePV.map(v => (v < 0 ? -v : 0))
+}
+
+export default {
+  computeSurvivalMonths,
+  computeFundingGaps
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,0 +1,68 @@
+import { createSelector } from 'reselect'
+import { frequencyToPayments } from '../utils/financeUtils'
+
+const getIncomeSources = state => state.incomeSources || []
+const getExpenses = state => state.expensesList || []
+const getGoals = state => state.goalsList || []
+const getStartYear = state => state.startYear || new Date().getFullYear()
+const getYears = state => state.years || 1
+const getDiscountRate = state => state.settings?.discountRate ?? state.discountRate ?? 0
+
+export const selectAnnualIncome = createSelector(
+  [getIncomeSources, getStartYear, getYears],
+  (sources, startYear, years) => {
+    return Array.from({ length: years }, (_, idx) => {
+      const year = startYear + idx
+      return sources.reduce((sum, src) => {
+        const afterTax = (Number(src.amount) || 0) * (1 - (src.taxRate || 0) / 100)
+        const freq = typeof src.frequency === 'number' ? src.frequency : 0
+        const sStart = src.startYear ?? startYear
+        const sEnd = src.endYear ?? startYear + years - 1
+        if (year < sStart || year > sEnd) return sum
+        const yrIndex = year - sStart
+        const growth = src.growth || 0
+        const annual = afterTax * freq * Math.pow(1 + growth / 100, yrIndex)
+        return sum + annual
+      }, 0)
+    })
+  }
+)
+
+export const selectAnnualOutflow = createSelector(
+  [getExpenses, getGoals, getStartYear, getYears],
+  (expenses, goals, startYear, years) => {
+    return Array.from({ length: years }, (_, idx) => {
+      const year = startYear + idx
+      const expTotal = expenses.reduce((sum, e) => {
+        const ppy = e.paymentsPerYear || frequencyToPayments(e.frequency) || 1
+        const growth = e.growth || 0
+        const base = (Number(e.amount) || 0) * ppy
+        return sum + base * Math.pow(1 + growth / 100, idx)
+      }, 0)
+      const goalsTotal = goals.reduce(
+        (s, g) => s + (g.targetYear === year ? Number(g.amount) || 0 : 0),
+        0
+      )
+      return expTotal + goalsTotal
+    })
+  }
+)
+
+export const selectDiscountedNet = createSelector(
+  [selectAnnualIncome, selectAnnualOutflow, getDiscountRate],
+  (income, outflow, rate) => {
+    const r = rate / 100
+    return income.map((inc, idx) => {
+      const net = inc - outflow[idx]
+      return net / Math.pow(1 + r, idx + 1)
+    })
+  }
+)
+
+export const selectCumulativePV = createSelector(
+  [selectDiscountedNet],
+  discounted => {
+    let sum = 0
+    return discounted.map(v => (sum += v))
+  }
+)


### PR DESCRIPTION
## Summary
- implement memoized selectors using reselect
- add adequacy engine utilities
- recompute new metrics inside FinanceContext
- test selector calculations and adequacy engine

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_6844a5c7e2908323bb796e9c1f8aad56