### PR TITLE
Add retirement age setting and salary auto-end

### DIFF
--- a/src/SettingsTab.jsx
+++ b/src/SettingsTab.jsx
@@ -122,6 +122,21 @@ export default function SettingsTab() {
           />
         </label>
 
+        {/* Retirement Age */}
+        <label className="block">
+          <span className="text-sm text-slate-600">Retirement Age</span>
+          <input
+            type="number"
+            min={0}
+            value={form.retirementAge}
+            onChange={e =>
+              handleChange('retirementAge', Math.max(0, parseInt(e.target.value) || 0))
+            }
+            className="w-full border rounded-md p-2"
+            title="Retirement age"
+          />
+        </label>
+
         {/* Buffer Percentage */}
         <label className="block">
           <span className="text-sm text-slate-600">Buffer Percentage (%)</span>

--- a/src/__tests__/incomeDuration.test.js
+++ b/src/__tests__/incomeDuration.test.js
@@ -43,3 +43,19 @@ test('income without endYear persists through horizon', () => {
   )
   expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(5000)
 })
+
+test('salary without endYear ends at retirement age', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ inflationRate: 0, retirementAge: 65 }))
+  localStorage.setItem('profile', JSON.stringify({ age: 60, lifeExpectancy: 90 }))
+  localStorage.setItem('incomeStartYear', String(current))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Job', type: 'Salary', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current }
+  ]))
+  render(
+    <FinanceProvider>
+      <PVDisplay years={10} />
+    </FinanceProvider>
+  )
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(5000)
+})


### PR DESCRIPTION
## Summary
- add `retirementAge` to finance settings and SettingsTab
- persist retirement age in FinanceContext
- stop salary streams at retirement age when no endYear
- update selectors and PV computations for retirement age
- test salary stream ending automatically at retirement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ab1e621083238f51472b4866a371