### PR TITLE
Add AdequacyAlert to track funding gaps

### DIFF
--- a/src/AdequacyAlert.jsx
+++ b/src/AdequacyAlert.jsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from 'react'
+import { useFinance } from './FinanceContext'
+import { computeFundingGaps } from './engines/adequacy'
+import { formatCurrency } from './utils/formatters'
+
+export default function AdequacyAlert() {
+  const { cumulativePV, startYear, settings } = useFinance()
+  const gaps = useMemo(() => computeFundingGaps(cumulativePV), [cumulativePV])
+  const rows = useMemo(
+    () =>
+      gaps
+        .map((gap, i) => (gap > 0 ? { year: startYear + i, gap } : null))
+        .filter(Boolean),
+    [gaps, startYear]
+  )
+  if (rows.length === 0) return null
+  return (
+    <div
+      id="adequacy-alert"
+      className="bg-red-50 border border-red-300 p-4 rounded-lg"
+    >
+      <h3 className="text-red-700 font-semibold mb-2">Adequacy Alert</h3>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="py-1 pr-2">Year</th>
+            <th className="py-1">Funding Gap</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.year} className="border-t">
+              <td className="py-1 pr-2">{r.year}</td>
+              <td className="py-1 text-right">
+                {formatCurrency(r.gap, settings.locale, settings.currency)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -15,6 +15,7 @@ import { useFinance } from './FinanceContext'
 import LTCMA from './ltcmaAssumptions'
 import InvestmentStrategies from './investmentStrategies'
 import { formatCurrency } from './utils/formatters'
+import AdequacyAlert from './AdequacyAlert'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 
@@ -200,6 +201,9 @@ export default function BalanceSheetTab() {
   return (
     <div className="space-y-6 p-6">
       <h2 className="text-xl font-semibold text-amber-700">Lifetime Balance Sheet</h2>
+      <a href="#adequacy-alert" className="text-sm underline text-amber-700 block">
+        View Funding Gaps
+      </a>
 
       <div className="mb-4 space-x-2">
         <label className="font-medium">Strategy:</label>
@@ -449,6 +453,7 @@ export default function BalanceSheetTab() {
           </ResponsiveContainer>
         </div>
       </div>
+      <AdequacyAlert />
     </div>
   )
 }

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -22,6 +22,7 @@ import calcDiscretionaryAdvice from './utils/discretionaryUtils';
 import generateLoanAdvice from './utils/loanAdvisoryEngine'
 import suggestLoanStrategies from './utils/suggestLoanStrategies'
 import AdviceDashboard from './AdviceDashboard'
+import AdequacyAlert from './AdequacyAlert'
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer,
 } from 'recharts';
@@ -382,6 +383,9 @@ export default function IncomeTab() {
         discretionaryAdvice={discretionaryAdvice}
         loanStrategies={loanStrategies}
       />
+      <a href="#adequacy-alert" className="text-sm underline text-amber-700 block">
+        View Funding Gaps
+      </a>
       {/* Income Streams Form */}
       <section>
         <h2 className="text-xl font-bold text-amber-700 mb-4">Income Sources</h2>
@@ -736,6 +740,8 @@ export default function IncomeTab() {
           </BarChart>
         </ResponsiveContainer>
       </section>
+
+      <AdequacyAlert />
 
       {/* Export */}
       <section>

--- a/src/__tests__/__snapshots__/adequacyAlert.test.js.snap
+++ b/src/__tests__/__snapshots__/adequacyAlert.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`shows funding gaps table 1`] = `
+<div
+  class="bg-red-50 border border-red-300 p-4 rounded-lg"
+  id="adequacy-alert"
+>
+  <h3
+    class="text-red-700 font-semibold mb-2"
+  >
+    Adequacy Alert
+  </h3>
+  <table
+    class="w-full text-sm"
+  >
+    <thead>
+      <tr
+        class="text-left"
+      >
+        <th
+          class="py-1 pr-2"
+        >
+          Year
+        </th>
+        <th
+          class="py-1"
+        >
+          Funding Gap
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="border-t"
+      >
+        <td
+          class="py-1 pr-2"
+        >
+          2025
+        </td>
+        <td
+          class="py-1 text-right"
+        >
+          Ksh 500.00
+        </td>
+      </tr>
+      <tr
+        class="border-t"
+      >
+        <td
+          class="py-1 pr-2"
+        >
+          2026
+        </td>
+        <td
+          class="py-1 text-right"
+        >
+          Ksh 1,000.00
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;

--- a/src/__tests__/adequacyAlert.test.js
+++ b/src/__tests__/adequacyAlert.test.js
@@ -1,0 +1,48 @@
+/* global test, expect, beforeAll, afterEach */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import AdequacyAlert from '../AdequacyAlert'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+test('renders nothing when no gaps', () => {
+  const { container } = render(
+    <FinanceProvider>
+      <AdequacyAlert />
+    </FinanceProvider>
+  )
+  expect(container.firstChild).toBeNull()
+})
+
+test('shows funding gaps table', async () => {
+  localStorage.setItem(
+    'incomeSources',
+    JSON.stringify([{ name: 'Job', amount: 1000, frequency: 1, growth: 0, taxRate: 0 }])
+  )
+  localStorage.setItem(
+    'expensesList',
+    JSON.stringify([{ name: 'Big', amount: 1500, paymentsPerYear: 1, growth: 0, priority: 1 }])
+  )
+  function Wrapper({ children }) {
+    const { setYears } = useFinance()
+    React.useEffect(() => { setYears(2) }, [setYears])
+    return children
+  }
+  const { container } = render(
+    <FinanceProvider>
+      <Wrapper>
+        <AdequacyAlert />
+      </Wrapper>
+    </FinanceProvider>
+  )
+  await screen.findByText('Adequacy Alert')
+  expect(screen.getAllByRole('row')).toHaveLength(3)
+  expect(container.firstChild).toMatchSnapshot()
+})


### PR DESCRIPTION
## Summary
- implement `AdequacyAlert` component that lists years with negative PV
- show a link to funding gaps and include the alert in Income and Balance Sheet tabs
- add snapshot and behavioural tests for the component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844ad9287ac83238f0aeef58479e6c7