### PR TITLE
Use dropdown for income frequency

### DIFF
--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -10,6 +10,7 @@
  */
 
 import React, { useMemo, useEffect, useState } from 'react';
+import { FREQUENCIES, FREQUENCY_LABELS } from './constants';
 import { useFinance } from './FinanceContext';
 import { calculatePV } from './utils/financeUtils';
 import { buildIncomeJSON, buildIncomeCSV, submitProfile } from './utils/exportHelpers'
@@ -436,16 +437,16 @@ export default function IncomeTab() {
               />
 
               <label className="block text-sm font-medium mt-2">Frequency (/yr)</label>
-              <input
-                type="number"
-                className="w-full border p-2 rounded-md invalid:border-red-500"
+              <select
+                className="w-full border p-2 rounded-md"
                 value={src.frequency}
                 onChange={e => onFieldChange(i, 'frequency', e.target.value)}
-                min={1}
-                step={1}
-                required
                 title="Payments per year"
-              />
+              >
+                {FREQUENCY_LABELS.map(label => (
+                  <option key={label} value={FREQUENCIES[label]}>{label}</option>
+                ))}
+              </select>
 
               <label className="block text-sm font-medium mt-2">Growth Rate (%)</label>
               <input

--- a/src/__tests__/incomeTab.frequency.test.js
+++ b/src/__tests__/incomeTab.frequency.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
 import IncomeTab from '../IncomeTab'
+import { FREQUENCY_LABELS } from '../constants'
 
 beforeAll(() => {
   global.ResizeObserver = class {
@@ -11,14 +12,14 @@ beforeAll(() => {
   }
 })
 
-test('frequency below 1 is corrected to 1', () => {
+test('frequency dropdown offers valid choices', () => {
   render(
     <FinanceProvider>
       <IncomeTab />
     </FinanceProvider>
   )
 
-  const input = screen.getAllByTitle('Payments per year')[0]
-  fireEvent.change(input, { target: { value: '0' } })
-  expect(input.value).toBe('1')
+  const select = screen.getAllByTitle('Payments per year')[0]
+  const labels = Array.from(select.options).map(o => o.textContent)
+  expect(labels).toEqual(FREQUENCY_LABELS)
 })


### PR DESCRIPTION
## Summary
- add FREQUENCY_LABELS dropdown to income sources
- test that frequency choices list is valid

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844af3a30048323b4356fd9507ca79d