### PR TITLE
Broadcast localStorage events across tabs

### DIFF
--- a/src/__tests__/storage.test.js
+++ b/src/__tests__/storage.test.js
@@ -36,4 +36,30 @@ describe('storage helpers', () => {
     expect(first).toEqual(['1'])
     expect(second).toEqual(['1', '2', null])
   })
+
+  test('updates in another tab trigger callbacks', () => {
+    const events = []
+    storage.subscribe('d', v => events.push(v))
+    localStorage.setItem('d', 'z')
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'd',
+      newValue: 'z',
+      oldValue: null,
+      storageArea: localStorage
+    }))
+    expect(events).toEqual(['z'])
+  })
+
+  test('removals in another tab trigger callbacks', () => {
+    const events = []
+    storage.subscribe('e', v => events.push(v))
+    localStorage.removeItem('e')
+    window.dispatchEvent(new StorageEvent('storage', {
+      key: 'e',
+      newValue: null,
+      oldValue: 'old',
+      storageArea: localStorage
+    }))
+    expect(events).toEqual([null])
+  })
 })

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -2,6 +2,14 @@ import mitt from 'mitt'
 
 const emitter = mitt()
 
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', event => {
+    if (event.storageArea === localStorage) {
+      emitter.emit(event.key, event.newValue)
+    }
+  })
+}
+
 const storage = {
   get(key) {
     return localStorage.getItem(key)


### PR DESCRIPTION
## Summary
- emit mitt events when `storage` events fire
- test cross-tab updates by dispatching `StorageEvent`

## Testing
- `npm test -- src/__tests__/storage.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b03a6a788323bf4340c9289f2171