### PR TITLE
Add cash-flow adequacy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Application settings are stored in local storage and can be modified under the *
 - `discretionaryCutThreshold` – percentage of monthly expenses that triggers discretionary advice
 - `survivalThresholdMonths` – minimum months of PV coverage considered healthy
 - `bufferPct` – buffer percent applied to loan strategy comparisons
+- `retirementAge` – age when salary streams automatically cease if no `endYear` is set
+
+Income sources now store a `startYear` and optional `endYear` so each stream can
+begin or stop during the projection horizon. Salaries without an `endYear` use
+`retirementAge` as the latest possible year.
 
 ## Hadi Persona Seed
 
@@ -140,6 +145,22 @@ import { buildIncomeJSON, buildPlanJSON, submitProfile } from './src/utils/expor
 ```
 
 Calling `submitProfile()` sends the generated JSON to the configured endpoint.
+
+## Cash-Flow Adequacy
+
+The file `src/engines/adequacy.js` exposes helpers for evaluating whether future
+cash flows cover upcoming expenses. `computeSurvivalMonths` delegates to the
+appropriate survival metric—nominal, PV or obligation based—while
+`computeFundingGaps` converts the cumulative present value stream into annual
+deficits. These functions power the Adequacy Alert described below.
+
+### Adequacy Alert
+
+The `AdequacyAlert` component consumes the `cumulativePV` array from
+`FinanceContext` and displays any funding gaps by year. It is rendered below the
+income projection chart on the **Income** tab and at the bottom of the
+**Balance Sheet** tab. A short "View Funding Gaps" link on each page scrolls to
+the alert when deficits exist.
 
 ## Manual Verification
 


### PR DESCRIPTION
## Summary
- document `retirementAge`, `startYear`, and `endYear`
- describe the cash-flow adequacy engine and Adequacy Alert component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b1099ef08323a9c29bee07b07d20