### PR TITLE
Improve income settings integration

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -424,6 +424,28 @@ export function FinanceProvider({ children }) {
     setIncludeLiabilitiesNPV,
   ])
 
+  // Auto-populate salary end year using retirement age
+  useEffect(() => {
+    setIncomeSources(prev => {
+      const diff = (settings.retirementAge ?? 65) - (profile.age ?? 0)
+      let changed = false
+      const next = prev.map(src => {
+        const t = String(src.type || '').toLowerCase()
+        const isSalary = t === 'salary' || t === 'employment'
+        if (isSalary && src.endYear == null) {
+          const base = src.startYear ?? startYear
+          const end = base + diff
+          if (src.endYear !== end) {
+            changed = true
+            return { ...src, endYear: end }
+          }
+        }
+        return src
+      })
+      return changed ? next : prev
+    })
+  }, [profile.age, settings.retirementAge, startYear])
+
   // === Persist state slices ===
   useEffect(() => { storage.set('incomeSources', JSON.stringify(incomeSources)) }, [incomeSources])
   useEffect(() => { storage.set('incomeStartYear', String(startYear)) }, [startYear])

--- a/src/IncomeTab.jsx
+++ b/src/IncomeTab.jsx
@@ -62,6 +62,13 @@ export default function IncomeTab() {
   const [chartView, setChartView] = useState('yearly');
   const [excludedForInterrupt, setExcludedForInterrupt] = useState([]);
 
+  // Keep local discount rate in sync with global settings
+  useEffect(() => {
+    if (settings.discountRate !== undefined && settings.discountRate !== discountRate) {
+      setDiscountRate(settings.discountRate)
+    }
+  }, [settings.discountRate])
+
   const currentYear = new Date().getFullYear();
   const pvGoals = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- auto-populate salary income end year based on profile age and retirement age
- keep income tab discount rate synced to global settings

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b3a47e408323b26f3ae96eb34759