### PR TITLE
Fix salary end year calculation

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -434,7 +434,7 @@ export function FinanceProvider({ children }) {
         const isSalary = t === 'salary' || t === 'employment'
         if (isSalary && src.endYear == null) {
           const base = src.startYear ?? startYear
-          const end = base + diff
+          const end = base + diff - 1
           if (src.endYear !== end) {
             changed = true
             return { ...src, endYear: end }

--- a/src/__tests__/incomeDuration.test.js
+++ b/src/__tests__/incomeDuration.test.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { FinanceProvider, useFinance } from '../FinanceContext'
 
 global.ResizeObserver = class { observe() {}; unobserve() {}; disconnect() {} }
@@ -12,6 +12,15 @@ function PVDisplay({ years }) {
   const { incomePV, setYears } = useFinance()
   useEffect(() => { setYears(years) }, [years, setYears])
   return <div data-testid="pv">{incomePV}</div>
+}
+
+function SalaryEnd() {
+  const { incomeSources, updateSettings, settings } = useFinance()
+  useEffect(() => {
+    updateSettings({ ...settings, retirementAge: settings.retirementAge + 1 })
+  }, [])
+  const end = incomeSources[0]?.endYear
+  return <div data-testid="end">{end}</div>
 }
 
 test('finite income stream stops at endYear', () => {
@@ -44,7 +53,7 @@ test('income without endYear persists through horizon', () => {
   expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(5000)
 })
 
-test('salary without endYear ends at retirement age', () => {
+test('salary without endYear ends at retirement age', async () => {
   const current = new Date().getFullYear()
   localStorage.setItem('settings', JSON.stringify({ inflationRate: 0, retirementAge: 65 }))
   localStorage.setItem('profile', JSON.stringify({ age: 60, lifeExpectancy: 90 }))
@@ -54,8 +63,12 @@ test('salary without endYear ends at retirement age', () => {
   ]))
   render(
     <FinanceProvider>
+      <SalaryEnd />
       <PVDisplay years={10} />
     </FinanceProvider>
   )
-  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(5000)
+  const diff = 66 - 60
+  await waitFor(() => Number(screen.getByTestId('end').textContent) > 0)
+  expect(Number(screen.getByTestId('end').textContent)).toBe(current + diff - 1)
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(6000)
 })


### PR DESCRIPTION
## Summary
- ensure salary end year stops one year before retirement
- verify derived end year in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b6d51aa88323a05f78752219cba9