### PR TITLE
Use cumulative PV for net worth in BalanceSheetTab

### DIFF
--- a/src/BalanceSheetTab.jsx
+++ b/src/BalanceSheetTab.jsx
@@ -23,6 +23,7 @@ export default function BalanceSheetTab() {
   const {
     incomePV,
     expensesPV,
+    cumulativePV,
     assetsList,
     setAssetsList,
     createAsset,
@@ -105,8 +106,16 @@ export default function BalanceSheetTab() {
   }, [expensesPV, setLiabilitiesList])
 
   const totalAssets = assetsList.reduce((sum, a) => sum + Number(a.amount || 0), 0)
-  const totalLiabilities = liabilitiesList.reduce((sum, l) => sum + Number(l.amount || l.principal || 0), 0)
-  const netWorth = totalAssets - totalLiabilities
+  const totalLiabilities = liabilitiesList.reduce(
+    (sum, l) => sum + Number(l.amount || l.principal || 0),
+    0
+  )
+
+  const pvIncome = assetsList.find(a => a.id === 'pv-income')?.amount || 0
+  const pvExpenses = liabilitiesList.find(l => l.id === 'pv-expenses')?.amount || 0
+  const baseNetWorth = totalAssets - pvIncome - (totalLiabilities - pvExpenses)
+  const futurePV = cumulativePV[cumulativePV.length - 1] || 0
+  const netWorth = baseNetWorth + futurePV
   const debtAssetRatio = totalAssets > 0 ? totalLiabilities / totalAssets : 0
 
   const currentYear = new Date().getFullYear()


### PR DESCRIPTION
## Summary
- use `cumulativePV` from context in `BalanceSheetTab`
- compute net worth using starting assets/liabilities plus discounted inflows/outflows

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844c386e6648323b824f05a1ebad3e8