### PR TITLE
Add README instructions for income views

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Application settings are stored in local storage and can be modified under the *
 - `expectedReturn` – expected yearly portfolio return
 - `currency` – default ISO currency code
 - `locale` – locale for number formatting
+- `discountRate` – rate used when discounting future cash flows
+- `projectionYears` – number of years to project on the Income tab
 - `apiEndpoint` – URL to POST exported data
 - `discretionaryCutThreshold` – percentage of monthly expenses that triggers discretionary advice
 - `survivalThresholdMonths` – minimum months of PV coverage considered healthy
@@ -161,6 +163,12 @@ The `AdequacyAlert` component consumes the `cumulativePV` array from
 income projection chart on the **Income** tab and at the bottom of the
 **Balance Sheet** tab. A short "View Funding Gaps" link on each page scrolls to
 the alert when deficits exist.
+
+## Income Views
+
+Above the income chart you'll find **Nominal** and **Discounted** buttons. Use
+them to toggle between raw projections and present value figures. The discount
+rate and projection horizon (Years) are both configured under **Settings**.
 
 ## Manual Verification
 


### PR DESCRIPTION
## Summary
- document discount rate and projection years settings
- explain how to toggle nominal vs discounted income

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844c51a54e88323941f632af78ca5f4