### PR TITLE
Implement header/sidebar layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,17 @@
 // src/App.jsx
 import React, { Suspense, useState } from 'react'
 import Spinner from './Spinner.jsx'
+import Header from './components/layout/Header.jsx'
+import Sidebar from './components/layout/Sidebar.jsx'
 
-const IncomeTab = React.lazy(() => import('./IncomeTab.jsx'))
-const ExpensesGoalsTab = React.lazy(() => import('./ExpensesGoalsTab.jsx'))
-const BalanceSheetTab = React.lazy(() => import('./BalanceSheetTab.jsx'))
-const ProfileTab = React.lazy(() => import('./ProfileTab.jsx'))
-const SettingsTab = React.lazy(() => import('./SettingsTab.jsx'))
-const InsuranceTab = React.lazy(() => import('./InsuranceTab.jsx'))
+const IncomeTab = React.lazy(() => import('./components/Income/IncomeTab.jsx'))
+const ExpensesGoalsTab = React.lazy(() => import('./components/ExpensesGoals/ExpensesGoalsTab.jsx'))
+const BalanceSheetTab = React.lazy(() => import('./components/BalanceSheet/BalanceSheetTab.jsx'))
+const ProfileTab = React.lazy(() => import('./components/Profile/ProfileTab.jsx'))
+const SettingsTab = React.lazy(() => import('./components/Settings/SettingsTab.jsx'))
+const InsuranceTab = React.lazy(() => import('./components/Insurance/InsuranceTab.jsx'))
 
 
-const tabs = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile', 'Insurance', 'Settings']
 const components = {
   Income: IncomeTab,
   'Expenses & Goals': ExpensesGoalsTab,
@@ -21,39 +22,21 @@ const components = {
 }
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState('Income')
-  const Active = components[activeTab]
+  const [activeSection, setActiveSection] = useState('Income')
+  const Active = components[activeSection]
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <h1 className="text-2xl font-bold mb-4">Personal Finance Planner</h1>
-
-      <nav
-        role="tablist"
-        className="flex space-x-4 border-b pb-2 mb-4 overflow-x-auto"
-      >
-        {tabs.map(tab => (
-          <button
-            role="tab"
-            aria-selected={activeTab === tab}
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={`px-3 py-1 rounded-t focus:outline-none focus:ring-2 focus:ring-amber-500 ${
-              activeTab === tab
-                ? 'bg-white shadow text-amber-700'
-                : 'text-slate-500 hover:text-amber-700'
-            }`}
-            title={tab}
-          >
-            {tab}
-          </button>
-        ))}
-      </nav>
-
-      <div className="bg-white p-4 rounded shadow min-h-[300px]">
-        <Suspense fallback={<Spinner />}>
-          <Active />
-        </Suspense>
+    <div className="min-h-screen flex">
+      <Sidebar activeSection={activeSection} onChange={setActiveSection} />
+      <div className="flex-1">
+        <Header />
+        <div className="max-w-4xl mx-auto p-6">
+          <div className="bg-white p-4 rounded shadow min-h-[300px]">
+            <Suspense fallback={<Spinner />}>
+              <Active />
+            </Suspense>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/__tests__/incomeTab.frequency.test.js
+++ b/src/__tests__/incomeTab.frequency.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
-import IncomeTab from '../IncomeTab'
+import IncomeTab from '../components/Income/IncomeTab'
 import { FREQUENCY_LABELS } from '../constants'
 
 beforeAll(() => {

--- a/src/__tests__/insuranceTab.integration.test.js
+++ b/src/__tests__/insuranceTab.integration.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
-import InsuranceTab from '../InsuranceTab'
+import InsuranceTab from '../components/Insurance/InsuranceTab'
 
 beforeAll(() => {
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }

--- a/src/__tests__/navigation.test.js
+++ b/src/__tests__/navigation.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App'
+import { FinanceProvider } from '../FinanceContext'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('sidebar navigation updates active section', async () => {
+  render(
+    <FinanceProvider>
+      <App />
+    </FinanceProvider>
+  )
+
+  await screen.findByText(/Income Sources/i)
+
+  fireEvent.click(screen.getByRole('tab', { name: /Profile/i }))
+  const profileHeading = await screen.findByText(/Client Profile/i)
+  expect(profileHeading).toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole('tab', { name: /Settings/i }))
+  const settingsHeading = await screen.findByText(/Global Settings/i)
+  expect(settingsHeading).toBeInTheDocument()
+})

--- a/src/__tests__/profileTab.lifeExpectancy.test.js
+++ b/src/__tests__/profileTab.lifeExpectancy.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
-import ProfileTab from '../ProfileTab'
+import ProfileTab from '../components/Profile/ProfileTab'
 
 beforeAll(() => {
   // ensure ResizeObserver not required

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -11,11 +11,11 @@ import {
   Pie,
   Cell,
 } from 'recharts'
-import { useFinance } from './FinanceContext'
-import LTCMA from './ltcmaAssumptions'
-import InvestmentStrategies from './investmentStrategies'
-import { formatCurrency } from './utils/formatters'
-import AdequacyAlert from './AdequacyAlert'
+import { useFinance } from '../../FinanceContext'
+import LTCMA from '../../ltcmaAssumptions'
+import InvestmentStrategies from '../../investmentStrategies'
+import { formatCurrency } from '../../utils/formatters'
+import AdequacyAlert from '../../AdequacyAlert'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -1,16 +1,16 @@
 // src/ExpensesGoalsTab.jsx
 
 import React, { useMemo, useEffect } from 'react'
-import { formatCurrency } from './utils/formatters'
-import { useFinance } from './FinanceContext'
-import { calculatePV, calculateLoanNPV } from './utils/financeUtils'
-import { FREQUENCIES, FREQUENCY_LABELS } from './constants'
-import suggestLoanStrategies from './utils/suggestLoanStrategies'
-import generateLoanAdvice from './utils/loanAdvisoryEngine'
-import AdviceDashboard from './AdviceDashboard'
-import calcDiscretionaryAdvice from './utils/discretionaryUtils'
-import { buildPlanJSON, buildPlanCSV, submitProfile } from './utils/exportHelpers'
-import storage from './utils/storage'
+import { formatCurrency } from '../../utils/formatters'
+import { useFinance } from '../../FinanceContext'
+import { calculatePV, calculateLoanNPV } from '../../utils/financeUtils'
+import { FREQUENCIES, FREQUENCY_LABELS } from '../../constants'
+import suggestLoanStrategies from '../../utils/suggestLoanStrategies'
+import generateLoanAdvice from '../../utils/loanAdvisoryEngine'
+import AdviceDashboard from '../../AdviceDashboard'
+import calcDiscretionaryAdvice from '../../utils/discretionaryUtils'
+import { buildPlanJSON, buildPlanCSV, submitProfile } from '../../utils/exportHelpers'
+import storage from '../../utils/storage'
 import {
   PieChart, Pie, Cell, Tooltip,
   BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -10,23 +10,23 @@
  */
 
 import React, { useMemo, useEffect, useState } from 'react';
-import { FREQUENCIES, FREQUENCY_LABELS } from './constants';
-import { useFinance } from './FinanceContext';
-import { calculatePV } from './utils/financeUtils';
-import { buildIncomeJSON, buildIncomeCSV, submitProfile } from './utils/exportHelpers'
+import { FREQUENCIES, FREQUENCY_LABELS } from '../../constants';
+import { useFinance } from '../../FinanceContext';
+import { calculatePV } from '../../utils/financeUtils';
+import { buildIncomeJSON, buildIncomeCSV, submitProfile } from '../../utils/exportHelpers'
 import {
   calculateNominalSurvival,
   calculatePVSurvival,
   calculatePVObligationSurvival
-} from './utils/survivalMetrics';
-import calcDiscretionaryAdvice from './utils/discretionaryUtils';
-import generateLoanAdvice from './utils/loanAdvisoryEngine'
-import suggestLoanStrategies from './utils/suggestLoanStrategies'
-import AdviceDashboard from './AdviceDashboard'
-import AdequacyAlert from './AdequacyAlert'
-import IncomeChart from './IncomeChart'
-import { formatCurrency } from './utils/formatters'
-import storage from './utils/storage'
+} from '../../utils/survivalMetrics';
+import calcDiscretionaryAdvice from '../../utils/discretionaryUtils';
+import generateLoanAdvice from '../../utils/loanAdvisoryEngine'
+import suggestLoanStrategies from '../../utils/suggestLoanStrategies'
+import AdviceDashboard from '../../AdviceDashboard'
+import AdequacyAlert from '../../AdequacyAlert'
+import IncomeChart from '../../IncomeChart'
+import { formatCurrency } from '../../utils/formatters'
+import storage from '../../utils/storage'
 
 export default function IncomeTab() {
   const {

--- a/src/components/Insurance/InsuranceTab.jsx
+++ b/src/components/Insurance/InsuranceTab.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { useFinance } from './FinanceContext'
-import { computeEmergencyFund, computeLifeCover } from './utils/insuranceUtils'
-import { formatCurrency } from './utils/formatters'
+import { useFinance } from '../../FinanceContext'
+import { computeEmergencyFund, computeLifeCover } from '../../utils/insuranceUtils'
+import { formatCurrency } from '../../utils/formatters'
 
 export default function InsuranceTab() {
   const { monthlyExpense, profile, settings } = useFinance()

--- a/src/components/Profile/ProfileTab.jsx
+++ b/src/components/Profile/ProfileTab.jsx
@@ -1,6 +1,6 @@
 // src/ProfileTab.jsx
 import React, { useState, useEffect } from 'react'
-import { useFinance } from './FinanceContext'
+import { useFinance } from '../../FinanceContext'
 
 export default function ProfileTab() {
   const { profile, updateProfile, riskScore } = useFinance()

--- a/src/components/Settings/SettingsTab.jsx
+++ b/src/components/Settings/SettingsTab.jsx
@@ -1,6 +1,6 @@
 // src/SettingsTab.jsx
 import React, { useState, useEffect } from 'react'
-import { useFinance } from './FinanceContext'
+import { useFinance } from '../../FinanceContext'
 
 export default function SettingsTab() {
   const {

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Header() {
+  return (
+    <header className="bg-amber-700 text-white p-4">
+      <h1 className="text-2xl font-bold">Personal Finance Planner</h1>
+    </header>
+  )
+}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+const sections = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile', 'Insurance', 'Settings']
+
+export default function Sidebar({ activeSection, onChange }) {
+  return (
+    <nav role="tablist" className="space-y-2 p-4 bg-white border-r min-w-[160px]">
+      {sections.map(sec => (
+        <button
+          key={sec}
+          role="tab"
+          aria-selected={activeSection === sec}
+          onClick={() => onChange(sec)}
+          className={`block w-full text-left px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-amber-500 ${
+            activeSection === sec ? 'bg-amber-50 text-amber-700 font-medium' : 'text-slate-700 hover:text-amber-700'
+          }`}
+          title={sec}
+        >
+          {sec}
+        </button>
+      ))}
+    </nav>
+  )
+}
+
+export { sections }


### PR DESCRIPTION
## Summary
- add Header and Sidebar layout components
- move tab components into feature folders
- update App to use the new layout
- fix imports after moving files
- test sidebar navigation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849db76af6083238984f76ea21bfb15