### PR TITLE
Add investment and strategy tabs with snapshots

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,12 +10,18 @@ const BalanceSheetTab = React.lazy(() => import('./components/BalanceSheet/Balan
 const ProfileTab = React.lazy(() => import('./components/Profile/ProfileTab.jsx'))
 const SettingsTab = React.lazy(() => import('./components/Settings/SettingsTab.jsx'))
 const InsuranceTab = React.lazy(() => import('./components/Insurance/InsuranceTab.jsx'))
+const InvestmentsTab = React.lazy(() => import('./components/Investments/InvestmentsTab.jsx'))
+const RetirementTab = React.lazy(() => import('./components/Retirement/RetirementTab.jsx'))
+const StrategyTab = React.lazy(() => import('./components/Strategy/StrategyTab.jsx'))
 
 
 const components = {
   Income: IncomeTab,
   'Expenses & Goals': ExpensesGoalsTab,
   'Balance Sheet': BalanceSheetTab,
+  Investments: InvestmentsTab,
+  Retirement: RetirementTab,
+  Strategy: StrategyTab,
   Profile: ProfileTab,
   Insurance: InsuranceTab,
   Settings: SettingsTab,

--- a/src/__tests__/__snapshots__/investmentsTab.test.js.snap
+++ b/src/__tests__/__snapshots__/investmentsTab.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`investments tab placeholder snapshot 1`] = `
+<h2
+  class="text-2xl font-bold text-amber-700"
+>
+  Investments
+</h2>
+`;

--- a/src/__tests__/__snapshots__/retirementTab.test.js.snap
+++ b/src/__tests__/__snapshots__/retirementTab.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`retirement tab placeholder snapshot 1`] = `
+<h2
+  class="text-2xl font-bold text-amber-700"
+>
+  Retirement
+</h2>
+`;

--- a/src/__tests__/__snapshots__/strategyTab.test.js.snap
+++ b/src/__tests__/__snapshots__/strategyTab.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`strategy tab placeholder snapshot 1`] = `
+<h2
+  class="text-2xl font-bold text-amber-700"
+>
+  Strategy
+</h2>
+`;

--- a/src/__tests__/investmentsTab.test.js
+++ b/src/__tests__/investmentsTab.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import InvestmentsTab from '../components/Investments/InvestmentsTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('investments tab placeholder snapshot', () => {
+  const { container } = render(
+    <FinanceProvider>
+      <InvestmentsTab />
+    </FinanceProvider>
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})

--- a/src/__tests__/retirementTab.test.js
+++ b/src/__tests__/retirementTab.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import RetirementTab from '../components/Retirement/RetirementTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('retirement tab placeholder snapshot', () => {
+  const { container } = render(
+    <FinanceProvider>
+      <RetirementTab />
+    </FinanceProvider>
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})

--- a/src/__tests__/strategyTab.test.js
+++ b/src/__tests__/strategyTab.test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import StrategyTab from '../components/Strategy/StrategyTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('strategy tab placeholder snapshot', () => {
+  const { container } = render(
+    <FinanceProvider>
+      <StrategyTab />
+    </FinanceProvider>
+  )
+  expect(container.firstChild).toMatchSnapshot()
+})

--- a/src/components/Investments/InvestmentsTab.jsx
+++ b/src/components/Investments/InvestmentsTab.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function InvestmentsTab() {
+  return <h2 className="text-2xl font-bold text-amber-700">Investments</h2>
+}

--- a/src/components/Retirement/RetirementTab.jsx
+++ b/src/components/Retirement/RetirementTab.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function RetirementTab() {
+  return <h2 className="text-2xl font-bold text-amber-700">Retirement</h2>
+}

--- a/src/components/Strategy/StrategyTab.jsx
+++ b/src/components/Strategy/StrategyTab.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function StrategyTab() {
+  return <h2 className="text-2xl font-bold text-amber-700">Strategy</h2>
+}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,6 +1,16 @@
 import React from 'react'
 
-const sections = ['Income', 'Expenses & Goals', 'Balance Sheet', 'Profile', 'Insurance', 'Settings']
+const sections = [
+  'Income',
+  'Expenses & Goals',
+  'Balance Sheet',
+  'Investments',
+  'Retirement',
+  'Strategy',
+  'Profile',
+  'Insurance',
+  'Settings',
+]
 
 export default function Sidebar({ activeSection, onChange }) {
   return (


### PR DESCRIPTION
## Summary
- add placeholder components for **Investments**, **Retirement**, and **Strategy**
- register new tabs in App and Sidebar
- provide snapshot tests covering each new tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dd1f31d8832385575551182edb4b