### PR TITLE
Adjust layout structure and sidebar width

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,17 +32,19 @@ export default function App() {
   const Active = components[activeTab]
 
   return (
-    <div className="min-h-screen flex">
-      <Sidebar activeTab={activeTab} onChange={setActiveTab} />
-      <div className="flex-1">
-        <Header setActiveTab={setActiveTab} />
-        <div className="max-w-4xl mx-auto p-6">
-          <div className="bg-white p-4 rounded shadow min-h-[300px]">
-            <Suspense fallback={<Spinner />}>
-              <Active />
-            </Suspense>
+    <div className="min-h-screen flex flex-col">
+      <Header setActiveTab={setActiveTab} />
+      <div className="flex flex-1">
+        <Sidebar activeTab={activeTab} onChange={setActiveTab} />
+        <main className="flex-1 overflow-y-auto p-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="bg-white p-4 rounded shadow min-h-[300px]">
+              <Suspense fallback={<Spinner />}>
+                <Active />
+              </Suspense>
+            </div>
           </div>
-        </div>
+        </main>
       </div>
     </div>
   )

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -14,7 +14,7 @@ const sections = [
 
 export default function Sidebar({ activeTab, onChange }) {
   return (
-    <nav role="tablist" className="space-y-2 p-4 bg-white border-r min-w-[160px]">
+    <nav role="tablist" className="space-y-2 p-4 bg-white border-r w-64">
       {sections.map(sec => (
         <button
           key={sec}


### PR DESCRIPTION
## Summary
- restructure App so header spans full width above sidebar
- expand sidebar width

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849e453ed3c8323b74980d51c5c49a4