### PR TITLE
Fix header alignment

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -23,13 +23,13 @@ function UserMenu() {
 export default function Header({ setActiveTab }) {
   return (
     <header className="bg-amber-400 text-white h-16 flex items-center justify-between px-6">
-      <h1 className="text-2xl font-bold">Personal Finance Planner</h1>
+      <h1 className="text-2xl font-bold leading-none">Personal Finance Planner</h1>
       <div className="flex items-center space-x-2">
         <button
           id="preferences-button"
           onClick={() => setActiveTab('Preferences')}
           aria-label="Preferences"
-          className="p-2 h-8 w-8 flex items-center justify-center rounded hover:bg-amber-300"
+          className="my-auto p-2 h-8 w-8 flex items-center justify-center rounded hover:bg-amber-300"
         >
           ⚙️
         </button>


### PR DESCRIPTION
## Summary
- align `h1` title by removing line-height
- vertically center the preferences button

## Testing
- `npm run lint --silent` *(fails: 7 errors, 35 warnings)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849e888c040832384bb8fe6aa46fe1e