### PR TITLE
Add responsive layout with header and sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,7 +14,6 @@ const InvestmentsTab = React.lazy(() => import('./components/Investments/Investm
 const RetirementTab = React.lazy(() => import('./components/Retirement/RetirementTab.jsx'))
 const StrategyTab = React.lazy(() => import('./tabs/StrategyTab.jsx'))
 
-
 const components = {
   Profile: ProfileTab,
   Preferences: PreferencesTab,
@@ -34,16 +33,12 @@ export default function App() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header setActiveTab={setActiveTab} />
-      <div className="flex flex-1">
-        <Sidebar activeTab={activeTab} onChange={setActiveTab} />
-        <main className="flex-1 overflow-y-auto p-6">
-          <div className="max-w-4xl mx-auto">
-            <div className="bg-white p-4 rounded shadow min-h-[300px]">
-              <Suspense fallback={<Spinner />}>
-                <Active />
-              </Suspense>
-            </div>
-          </div>
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar activeTab={activeTab} onSelect={setActiveTab} />
+        <main className="flex-1 overflow-y-auto bg-gray-50 p-6">
+          <Suspense fallback={<Spinner />}>
+            <Active />
+          </Suspense>
         </main>
       </div>
     </div>

--- a/src/__tests__/__snapshots__/strategyTab.test.js.snap
+++ b/src/__tests__/__snapshots__/strategyTab.test.js.snap
@@ -2,15 +2,15 @@
 
 exports[`strategy tab placeholder snapshot 1`] = `
 <div
-  class="bg-white rounded-xl shadow p-4"
+  class="bg-white rounded-xl shadow p-6"
 >
   <h2
-    class="text-2xl font-semibold mb-2 text-amber-400"
+    class="text-2xl font-semibold mb-4 text-amber-400"
   >
     Strategy
   </h2>
   <div
-    class="h-40 flex items-center justify-center text-gray-400"
+    class="h-48 flex items-center justify-center text-gray-400"
   >
     [Financial Strategy Recommendations & Scenarios]
   </div>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,35 +1,15 @@
-import React, { useState } from 'react'
-
-function UserMenu() {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="relative">
-      <button onClick={() => setOpen(o => !o)} className="px-3 py-2 bg-white text-amber-400 rounded-md">
-        Menu
-      </button>
-      {open && (
-        <ul className="absolute right-0 mt-2 w-48 bg-white shadow-lg rounded-md">
-          {['Notifications','Help & Support','Logout / Switch User'].map(item => (
-            <li key={item}>
-              <button className="w-full text-left px-4 py-2 text-amber-400 hover:bg-amber-50">{item}</button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  )
-}
+import React from 'react'
+import UserMenu from './UserMenu.jsx'
 
 export default function Header({ setActiveTab }) {
   return (
-    <header className="bg-amber-400 text-white h-16 flex items-center justify-between px-6">
-      <h1 className="text-2xl font-bold leading-none">Personal Finance Planner</h1>
-      <div className="flex items-center space-x-2">
+    <header className="bg-amber-400 h-14 flex items-center justify-between px-6 shadow">
+      <h1 className="text-xl font-semibold leading-tight text-white">Personal Finance Planner</h1>
+      <div className="flex items-center h-full space-x-4">
         <button
-          id="preferences-button"
           onClick={() => setActiveTab('Preferences')}
+          className="h-10 w-10 flex items-center justify-center bg-white rounded hover:bg-amber-300"
           aria-label="Preferences"
-          className="my-auto p-2 h-8 w-8 flex items-center justify-center rounded hover:bg-amber-300"
         >
           ⚙️
         </button>
@@ -38,5 +18,3 @@ export default function Header({ setActiveTab }) {
     </header>
   )
 }
-
-export { UserMenu }

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -12,24 +12,30 @@ const sections = [
   'Insurance',
 ]
 
-export default function Sidebar({ activeTab, onChange }) {
+export default function Sidebar({ activeTab, onSelect }) {
   return (
-    <nav role="tablist" className="space-y-2 p-4 bg-white border-r w-64">
-      {sections.map(sec => (
-        <button
-          key={sec}
-          role="tab"
-          aria-selected={activeTab === sec}
-          onClick={() => onChange(sec)}
-          className={`block w-full text-left px-3 py-2 rounded focus:outline-none focus:ring-2 focus:ring-amber-500 ${
-            activeTab === sec ? 'bg-amber-50 text-amber-700 font-medium' : 'text-slate-700 hover:text-amber-700 hover:bg-amber-50'
-          }`}
-          title={sec}
-        >
-          {sec}
-        </button>
-      ))}
-    </nav>
+    <aside className="w-72 bg-white border-r overflow-y-auto">
+      <div className="p-6">
+        <h2 className="text-lg font-medium text-amber-400 mb-4">Getting Started</h2>
+        <nav className="space-y-2" role="tablist">
+          {sections.map(tab => (
+            <button
+              key={tab}
+              role="tab"
+              aria-selected={activeTab === tab}
+              onClick={() => onSelect(tab)}
+              className={`block w-full text-left px-4 py-2 rounded ${
+                activeTab === tab
+                  ? 'bg-amber-50 font-medium'
+                  : 'hover:bg-amber-50 text-slate-700'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </div>
+    </aside>
   )
 }
 

--- a/src/components/layout/UserMenu.jsx
+++ b/src/components/layout/UserMenu.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useRef, useEffect } from 'react'
+
+export default function UserMenu() {
+  const [open, setOpen] = useState(false)
+  const ref = useRef()
+
+  useEffect(() => {
+    const handleClickOutside = e => {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false)
+    }
+    document.addEventListener('click', handleClickOutside)
+    return () => document.removeEventListener('click', handleClickOutside)
+  }, [])
+
+  return (
+    <div ref={ref} className="relative h-full flex items-center">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="h-10 px-4 bg-white text-amber-400 rounded hover:bg-amber-50"
+      >
+        Menu
+      </button>
+      {open && (
+        <ul className="absolute right-0 top-full mt-1 w-48 bg-white shadow-lg rounded">
+          {['Notifications', 'Help & Support', 'Logout'].map(item => (
+            <li key={item}>
+              <button className="w-full text-left px-4 py-2 text-amber-400 hover:bg-amber-50">
+                {item}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/tabs/StrategyTab.jsx
+++ b/src/tabs/StrategyTab.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React from 'react'
 export default function StrategyTab() {
   return (
-    <div className="bg-white rounded-xl shadow p-4">
-      <h2 className="text-2xl font-semibold mb-2 text-amber-400">Strategy</h2>
-      <div className="h-40 flex items-center justify-center text-gray-400">
+    <div className="bg-white rounded-xl shadow p-6">
+      <h2 className="text-2xl font-semibold mb-4 text-amber-400">Strategy</h2>
+      <div className="h-48 flex items-center justify-center text-gray-400">
         [Financial Strategy Recommendations & Scenarios]
       </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- restructure `App.jsx` layout with header and sidebar
- refactor `Header` and `Sidebar` components
- add new `UserMenu` component
- tweak `StrategyTab` styling
- update snapshot

## Testing
- `npm run lint` *(fails: no-unused-vars errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849ecbf11d48323af6eb7a494d22f13