### PR TITLE
Implement Income tab improvements

### DIFF
--- a/src/AdequacyAlert.jsx
+++ b/src/AdequacyAlert.jsx
@@ -3,7 +3,7 @@ import { useFinance } from './FinanceContext'
 import { computeFundingGaps } from './engines/adequacy'
 import { formatCurrency } from './utils/formatters'
 
-export default function AdequacyAlert() {
+export default function AdequacyAlert({ message }) {
   const { cumulativePV, startYear, settings } = useFinance()
   const gaps = useMemo(() => computeFundingGaps(cumulativePV), [cumulativePV])
   const rows = useMemo(
@@ -13,6 +13,17 @@ export default function AdequacyAlert() {
         .filter(Boolean),
     [gaps, startYear]
   )
+  if (message) {
+    return (
+      <div
+        id="adequacy-alert"
+        className="bg-red-50 border border-red-300 p-4 rounded-lg"
+      >
+        <h3 className="text-red-700 font-semibold mb-2">Adequacy Alert</h3>
+        <p className="text-sm">{message}</p>
+      </div>
+    )
+  }
   if (rows.length === 0) return null
   return (
     <div

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -126,6 +126,7 @@ export function FinanceProvider({ children }) {
       taxRate: 30,
       startYear: now,
       endYear: null,
+      active: true,
     }]
     if (s) {
       try {
@@ -133,6 +134,7 @@ export function FinanceProvider({ children }) {
         const migrated = parsed.map(src => ({
           startYear: src.startYear ?? now,
           endYear: src.endYear ?? null,
+          active: src.active !== false,
           ...src,
         }))
         storage.set('incomeSources', JSON.stringify(migrated))
@@ -479,6 +481,7 @@ export function FinanceProvider({ children }) {
 
   useEffect(() => {
     const monthlyIncome = incomeSources.reduce((sum, src) => {
+      if (src.active === false) return sum
       const afterTax = src.amount * (1 - (src.taxRate || 0) / 100)
       return sum + (afterTax * src.frequency) / 12
     }, 0)
@@ -574,6 +577,7 @@ export function FinanceProvider({ children }) {
     const planStart = startYear
     const planEnd = startYear + years - 1
     return incomeSources.reduce((sum, src) => {
+      if (src.active === false) return sum
       const afterTaxAmt = src.amount * (1 - (src.taxRate || 0) / 100)
       const growth = src.growth || 0
       const srcStart = Math.max(src.startYear ?? planStart, planStart)

--- a/src/__tests__/adequacyAlert.test.js
+++ b/src/__tests__/adequacyAlert.test.js
@@ -46,3 +46,13 @@ test('shows funding gaps table', async () => {
   expect(screen.getAllByRole('row')).toHaveLength(3)
   expect(container.firstChild).toMatchSnapshot()
 })
+
+test('renders custom message when provided', () => {
+  render(
+    <FinanceProvider>
+      <AdequacyAlert message="Consider insurance" />
+    </FinanceProvider>
+  )
+  expect(screen.getByText('Adequacy Alert')).toBeInTheDocument()
+  expect(screen.getByText('Consider insurance')).toBeInTheDocument()
+})

--- a/src/__tests__/incomeTab.frequency.test.js
+++ b/src/__tests__/incomeTab.frequency.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
 import IncomeTab from '../components/Income/IncomeTab'
-import { FREQUENCY_LABELS } from '../constants'
 
 beforeAll(() => {
   global.ResizeObserver = class {
@@ -12,14 +11,13 @@ beforeAll(() => {
   }
 })
 
-test('frequency dropdown offers valid choices', () => {
+test('frequency input enforces minimum', () => {
   render(
     <FinanceProvider>
       <IncomeTab />
     </FinanceProvider>
   )
 
-  const select = screen.getAllByTitle('Payments per year')[0]
-  const labels = Array.from(select.options).map(o => o.textContent)
-  expect(labels).toEqual(FREQUENCY_LABELS)
+  const input = screen.getAllByLabelText('Payments per year')[0]
+  expect(input).toHaveAttribute('min', '1')
 })

--- a/src/__tests__/incomeTab.integration.test.js
+++ b/src/__tests__/incomeTab.integration.test.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import IncomeTab from '../components/Income/IncomeTab'
+
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } })
+
+afterEach(() => { localStorage.clear() })
+
+test('income source interactions and advisory', () => {
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Job', amount: 1000, frequency: 1, growth: 0, taxRate: 0, type: 'Salary', active: true },
+    { name: 'Bonus', amount: 500, frequency: 1, growth: 0, taxRate: 0, type: 'Bonus', active: true }
+  ]))
+  localStorage.setItem('monthlyExpense', '2000')
+
+  render(
+    <FinanceProvider>
+      <IncomeTab />
+    </FinanceProvider>
+  )
+
+  expect(screen.getByText(/Total PV/)).toHaveTextContent('1,500')
+  expect(screen.getByText(/Stability/)).toHaveTextContent('77%')
+
+  fireEvent.click(screen.getByLabelText('Add income source'))
+  const amounts = screen.getAllByLabelText('Income amount')
+  fireEvent.change(amounts[2], { target: { value: '200' } })
+  expect(amounts[2]).toHaveValue(200)
+  window.confirm = jest.fn(() => true)
+  fireEvent.click(screen.getAllByRole('button', { name: /Delete/ })[2])
+  
+  const toggles = screen.getAllByLabelText('Include this income in projection')
+  fireEvent.click(toggles[1])
+  expect(screen.getByText(/Total PV/)).toHaveTextContent('1,000')
+  expect(screen.getByText(/Stability/)).toHaveTextContent('100%')
+  fireEvent.click(toggles[0])
+  expect(screen.getByText(/Stability/)).toHaveTextContent('0%')
+})

--- a/src/components/Income/IncomeSourceRow.jsx
+++ b/src/components/Income/IncomeSourceRow.jsx
@@ -1,0 +1,139 @@
+import React from 'react'
+
+export default function IncomeSourceRow({ income, index, updateIncome, deleteIncome, currency }) {
+  return (
+    <div className="bg-white p-4 rounded-xl shadow-md relative transition-all">
+      <label className="block text-sm font-medium">Source Name</label>
+      <input
+        type="text"
+        className="w-full border p-2 rounded-md"
+        value={income.name}
+        onChange={e => updateIncome(index, 'name', e.target.value)}
+        required
+        aria-label="Income source name"
+        title="Income source name"
+      />
+
+      <label className="block text-sm font-medium mt-2">Type</label>
+      <select
+        className="w-full border p-2 rounded-md"
+        value={income.type}
+        onChange={e => updateIncome(index, 'type', e.target.value)}
+        aria-label="Income type"
+        title="Income type"
+      >
+        <option value="Salary">Salary</option>
+        <option value="Freelance">Freelance</option>
+        <option value="Bonus">Bonus</option>
+      </select>
+
+      <label className="block text-sm font-medium mt-2">Amount ({currency})</label>
+      <input
+        type="number"
+        className="w-full border p-2 rounded-md"
+        value={income.amount}
+        onChange={e => {
+          let val = Number(e.target.value)
+          if (val < 0) val = 0
+          updateIncome(index, 'amount', val)
+        }}
+        min={0}
+        step={0.01}
+        required
+        aria-label="Income amount"
+        title="Income amount"
+      />
+
+      <label className="block text-sm font-medium mt-2">Frequency (/yr)</label>
+      <input
+        type="number"
+        className="w-full border p-2 rounded-md"
+        value={income.frequency}
+        onChange={e => {
+          let val = Number(e.target.value)
+          if (val < 1) val = 1
+          updateIncome(index, 'frequency', val)
+        }}
+        min={1}
+        required
+        aria-label="Payments per year"
+        title="Payments per year"
+      />
+
+      <label className="block text-sm font-medium mt-2">Growth Rate (%)</label>
+      <input
+        type="number"
+        className="w-full border p-2 rounded-md"
+        value={income.growth}
+        onChange={e => {
+          let val = Number(e.target.value)
+          if (val < 0) val = 0
+          if (val > 20) val = 20
+          updateIncome(index, 'growth', val)
+        }}
+        step={0.1}
+        min={0}
+        max={20}
+        aria-label="Growth rate"
+        title="Growth rate"
+      />
+
+      <label className="block text-sm font-medium mt-2">Tax Rate (%)</label>
+      <input
+        type="number"
+        className="w-full border p-2 rounded-md"
+        value={income.taxRate}
+        onChange={e => updateIncome(index, 'taxRate', Number(e.target.value))}
+        min={0}
+        max={100}
+        step={0.1}
+        required
+        aria-label="Tax rate"
+        title="Tax rate"
+      />
+
+      <label className="block text-sm font-medium mt-2">Start Year</label>
+      <input
+        type="date"
+        className="w-full border p-2 rounded-md"
+        value={`${income.startYear}-01-01`}
+        onChange={e => updateIncome(index, 'startYear', e.target.value)}
+        aria-label="Start year"
+        title="Start year"
+      />
+
+      <label className="block text-sm font-medium mt-2">End Year</label>
+      <input
+        type="date"
+        className="w-full border p-2 rounded-md"
+        value={income.endYear ? `${income.endYear}-01-01` : ''}
+        onChange={e => updateIncome(index, 'endYear', e.target.value)}
+        aria-label="End year"
+        title="End year"
+      />
+
+      <label className="block text-sm font-medium mt-2">
+        <input
+          type="checkbox"
+          className="mr-1"
+          checked={income.active}
+          onChange={e => updateIncome(index, 'active', e.target.checked)}
+          aria-label="Include this income in projection"
+          title="Include this income in projection"
+        />
+        Include in Projection
+      </label>
+
+      <button
+        onClick={() => {
+          if (window.confirm(`Delete ${income.name}?`)) deleteIncome(index)
+        }}
+        className="absolute top-1 right-1 text-xl"
+        aria-label={`Delete ${income.name} income stream`}
+        title={`Delete ${income.name}`}
+      >
+        ❌
+      </button>
+    </div>
+  )
+}

--- a/src/components/Income/IncomeTimelineChart.jsx
+++ b/src/components/Income/IncomeTimelineChart.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts'
+import { formatCurrency } from '../../utils/formatters'
+
+export function generateIncomeTimeline(sources, years) {
+  const timeline = Array.from({ length: years }, (_, i) => ({ year: i + 1, total: 0 }))
+  sources.forEach(src => {
+    if (!src.active) return
+    for (let i = 0; i < years; i++) {
+      const grown = src.amount * src.frequency * Math.pow(1 + src.growth / 100, i)
+      timeline[i].total += grown
+    }
+  })
+  return timeline
+}
+
+export default function IncomeTimelineChart({ data, locale, currency }) {
+  const format = v => formatCurrency(v, locale, currency)
+  return (
+    <ResponsiveContainer width="100%" height={300} role="img" aria-label="Income timeline chart">
+      <LineChart data={data}>
+        <XAxis dataKey="year" />
+        <YAxis />
+        <Tooltip formatter={format} />
+        <Legend />
+        <Line type="monotone" dataKey="total" stroke="#f59e0b" name="Income" />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -16,6 +16,7 @@ export const selectAnnualIncome = createSelector(
     return Array.from({ length: years }, (_, idx) => {
       const year = startYear + idx
       return sources.reduce((sum, src) => {
+        if (src.active === false) return sum
         const afterTax = (Number(src.amount) || 0) * (1 - (src.taxRate || 0) / 100)
         const freq = typeof src.frequency === 'number' ? src.frequency : 0
         const sStart = src.startYear ?? startYear


### PR DESCRIPTION
## Summary
- add optional `message` prop to `AdequacyAlert`
- support inactive income sources and refactor calculations
- build new `IncomeSourceRow` and `IncomeTimelineChart` components
- enhance `IncomeTab` with validation, stability badge and charts
- update selectors for active flag
- extend tests for `AdequacyAlert` and Income tab interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fdcd5065483238d8e398a88b753e7