### PR TITLE
Add income timeline by source

### DIFF
--- a/src/__tests__/exportHelpers.test.js
+++ b/src/__tests__/exportHelpers.test.js
@@ -2,10 +2,11 @@ import { buildIncomeJSON, buildIncomeCSV, buildPlanJSON, buildPlanCSV } from '..
 
 test('income JSON payload contains profile fields', () => {
   const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
-  const payload = buildIncomeJSON(profile, 2024, [], 5, 10, 1000, [], 0)
+  const payload = buildIncomeJSON(profile, 2024, [], 5, 10, 1000, [], 0, [])
   expect(payload.profile.email).toBe('test@example.com')
   expect(payload.profile.phone).toBe('555-1234')
   expect(payload.profile.residentialAddress).toBe('123 St')
+  expect(Array.isArray(payload.timeline)).toBe(true)
 })
 
 test('income CSV includes profile header', () => {

--- a/src/components/Income/IncomeSourceRow.jsx
+++ b/src/components/Income/IncomeSourceRow.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default function IncomeSourceRow({ income, index, updateIncome, deleteIncome, currency }) {
+export default function IncomeSourceRow({ income, index, updateIncome, deleteIncome, currency, assetsList = [] }) {
   return (
     <div className="bg-white p-4 rounded-xl shadow-md relative transition-all">
       <label className="block text-sm font-medium">Source Name</label>
@@ -113,15 +113,21 @@ export default function IncomeSourceRow({ income, index, updateIncome, deleteInc
         title="End year"
       />
 
-      <label className="block text-sm font-medium mt-2">Linked Asset ID (optional)</label>
-      <input
-        type="text"
+      <label className="block text-sm font-medium mt-2">Linked Asset (optional)</label>
+      <select
         className="w-full border p-2 rounded-md"
         value={income.linkedAssetId || ''}
         onChange={e => updateIncome(index, 'linkedAssetId', e.target.value)}
-        aria-label="Linked Asset ID (optional)"
-        title="Linked Asset ID"
-      />
+        aria-label="Linked asset"
+        title="Linked asset"
+      >
+        <option value=""></option>
+        {assetsList.map(a => (
+          <option key={a.id} value={a.id}>
+            {a.name || a.id}
+          </option>
+        ))}
+      </select>
 
       <label className="block text-sm font-medium mt-2">
         <input

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -1,6 +1,16 @@
 import { buildCSV, quoteCSV } from './csvUtils'
 
-export function buildIncomeJSON(profile, startYear, incomeSources, discountRate, years, monthlyExpense, pvPerStream, totalPV) {
+export function buildIncomeJSON(
+  profile,
+  startYear,
+  incomeSources,
+  discountRate,
+  years,
+  monthlyExpense,
+  pvPerStream,
+  totalPV,
+  timeline = []
+) {
   return {
     generatedAt: new Date().toISOString(),
     profile,
@@ -9,6 +19,7 @@ export function buildIncomeJSON(profile, startYear, incomeSources, discountRate,
     assumptions: { discountRate, years, monthlyExpense },
     pvPerStream,
     totalPV,
+    timeline,
   }
 }
 


### PR DESCRIPTION
## Summary
- project income until linked asset ends
- allow linking income sources to balance sheet assets
- chart multi-source income timeline
- export timeline in income JSON payload
- color survival badge by months of coverage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684fe6c265148323b331da3c21da9c7a