### PR TITLE
Add dynamic income link to assets

### DIFF
--- a/src/__tests__/incomeDuration.test.js
+++ b/src/__tests__/incomeDuration.test.js
@@ -69,3 +69,37 @@ test('salary without endYear ends at retirement age', async () => {
   expect(Number(screen.getByTestId('end').textContent)).toBe(current + diff - 1)
   expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(6000)
 })
+
+test('linked asset sale year caps income', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ inflationRate: 0, startYear: current }))
+  localStorage.setItem('assetsList', JSON.stringify([
+    { id: 'a1', name: 'House', amount: 0, type: 'Property', purchaseYear: current, saleYear: current + 2, principal: 100000 }
+  ]))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Rent', type: 'Rental', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current, linkedAssetId: 'a1' }
+  ]))
+  render(
+    <FinanceProvider>
+      <PVDisplay years={5} />
+    </FinanceProvider>
+  )
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(3000)
+})
+
+test('manual endYear overrides linked asset', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ inflationRate: 0, startYear: current }))
+  localStorage.setItem('assetsList', JSON.stringify([
+    { id: 'a2', name: 'Bond', amount: 0, type: 'Bond', purchaseYear: current, saleYear: current + 1, principal: 10000 }
+  ]))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Interest', type: 'Bond', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current, endYear: current + 2, linkedAssetId: 'a2' }
+  ]))
+  render(
+    <FinanceProvider>
+      <PVDisplay years={5} />
+    </FinanceProvider>
+  )
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(3000)
+})

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -161,7 +161,10 @@ export default function BalanceSheetTab() {
   const updateItem = (setList, list, index, field, value) => {
     const updatedItem = {
       ...list[index],
-      [field]: field === 'amount' ? Number(value) : value,
+      [field]:
+        ['amount', 'expectedReturn', 'volatility', 'horizonYears', 'purchaseYear', 'saleYear', 'principal'].includes(field)
+          ? Number(value)
+          : value,
     }
     if (setList === setAssetsList && field === 'type' && LTCMA[value]) {
       updatedItem.expectedReturn = LTCMA[value].expectedReturn
@@ -322,6 +325,30 @@ export default function BalanceSheetTab() {
                     onChange={e => updateItem(setAssetsList, assetsList, i, 'horizonYears', e.target.value)}
                     aria-label="Horizon years"
                     title="Horizon years"
+                  />
+                  <input
+                    type="number"
+                    className="border p-2 rounded-md text-right"
+                    value={item.purchaseYear ?? ''}
+                    onChange={e => updateItem(setAssetsList, assetsList, i, 'purchaseYear', e.target.value)}
+                    aria-label="Purchase year"
+                    title="Purchase year"
+                  />
+                  <input
+                    type="number"
+                    className="border p-2 rounded-md text-right"
+                    value={item.saleYear ?? ''}
+                    onChange={e => updateItem(setAssetsList, assetsList, i, 'saleYear', e.target.value)}
+                    aria-label="Sale year"
+                    title="Sale year"
+                  />
+                  <input
+                    type="number"
+                    className="border p-2 rounded-md text-right"
+                    value={item.principal ?? ''}
+                    onChange={e => updateItem(setAssetsList, assetsList, i, 'principal', e.target.value)}
+                    aria-label="Principal"
+                    title="Principal"
                   />
                 </div>
               )}

--- a/src/components/Income/IncomeSourceRow.jsx
+++ b/src/components/Income/IncomeSourceRow.jsx
@@ -108,7 +108,8 @@ export default function IncomeSourceRow({ income, index, updateIncome, deleteInc
         type="number"
         className="w-full border p-2 rounded-md"
         value={income.endYear ?? ''}
-        onChange={e => updateIncome(index, 'endYear', e.target.value)}
+        onChange={e => updateIncome(index, 'endYear', Number(e.target.value) || null)}
+        placeholder="Auto"
         aria-label="End year"
         title="End year"
       />
@@ -116,16 +117,14 @@ export default function IncomeSourceRow({ income, index, updateIncome, deleteInc
       <label className="block text-sm font-medium mt-2">Linked Asset (optional)</label>
       <select
         className="w-full border p-2 rounded-md"
-        value={income.linkedAssetId || ''}
+        value={income.linkedAssetId}
         onChange={e => updateIncome(index, 'linkedAssetId', e.target.value)}
         aria-label="Linked asset"
         title="Linked asset"
       >
-        <option value=""></option>
-        {assetsList.map(a => (
-          <option key={a.id} value={a.id}>
-            {a.name || a.id}
-          </option>
+        <option value="">-- None --</option>
+        {assetsList.map(asset => (
+          <option key={asset.id} value={asset.id}>{asset.name || asset.type}</option>
         ))}
       </select>
 


### PR DESCRIPTION
## Summary
- extend asset records with purchase year, sale year and principal
- generalize income projection with getStreamEndYear and projectIncomeStream
- sync income PV calculations with linked assets
- expose asset link and end-year override in Income tab
- allow editing asset purchase/sale/principal
- test income duration with linked assets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ffc86f1048323b19f3f7080d9e70e