### PR TITLE
Add net PV metrics and improved income timeline

### DIFF
--- a/src/__tests__/incomeTab.integration.test.js
+++ b/src/__tests__/incomeTab.integration.test.js
@@ -20,7 +20,7 @@ test('income source interactions and advisory', () => {
     </FinanceProvider>
   )
 
-  expect(screen.getByText(/Total PV/)).toHaveTextContent('1,500')
+  expect(screen.getByText(/Total PV \(Gross\)/)).toHaveTextContent('54,000')
   expect(screen.getByText(/Stability/)).toHaveTextContent('77%')
 
   fireEvent.click(screen.getByLabelText('Add income source'))
@@ -32,7 +32,7 @@ test('income source interactions and advisory', () => {
   
   const toggles = screen.getAllByLabelText('Include in Projection')
   fireEvent.click(toggles[1])
-  expect(screen.getByText(/Total PV/)).toHaveTextContent('1,000')
+  expect(screen.getByText(/Total PV \(Gross\)/)).toHaveTextContent('36,000')
   expect(screen.getByText(/Stability/)).toHaveTextContent('100%')
   fireEvent.click(toggles[0])
   expect(screen.getByText(/Stability/)).toHaveTextContent('0%')

--- a/src/components/Income/IncomeTimelineChart.jsx
+++ b/src/components/Income/IncomeTimelineChart.jsx
@@ -1,35 +1,19 @@
 import React from 'react'
-import { BarChart, Bar, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
-const COLORS = ['#fbbf24', '#f59e0b', '#d97706', '#92400e', '#78350f']
 
-export default function IncomeTimelineChart({ data = [], incomeSources = [], locale, currency }) {
+export default function IncomeTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <BarChart data={data} width={1000} height={500} role="img" aria-label="Income timeline chart">
+    <LineChart data={data} width={1000} height={500} role="img" aria-label="Income timeline chart">
       <XAxis dataKey="year" />
       <YAxis />
       <Tooltip formatter={format} />
       <Legend />
-
-      {incomeSources.filter(s => s.active).map((s, idx) => (
-        <Bar
-          key={s.id}
-          dataKey={s.id}
-          name={s.name}
-          stackId="income"
-          fill={COLORS[idx % COLORS.length]}
-        />
-      ))}
-
-      <Line
-        type="monotone"
-        dataKey="expenses"
-        name="Expenses"
-        stroke="#ef4444"
-        strokeWidth={2}
-      />
-    </BarChart>
+      <Line dataKey="gross" stroke="#f59e0b" name="Gross Income" />
+      <Line dataKey="net" stroke="#16a34a" name="After Tax" />
+      <Line dataKey="expenses" stroke="#ef4444" name="Expenses" strokeWidth={2} />
+    </LineChart>
   )
 }

--- a/src/components/Income/helpers.js
+++ b/src/components/Income/helpers.js
@@ -1,0 +1,42 @@
+export function findLinkedAsset(id, assetsList = []) {
+  return assetsList.find(a => a.id === id);
+}
+
+export function calculatePV(stream, discountRate, years, assumptions, linkedAsset) {
+  const startYear = Math.max(new Date().getFullYear(), stream.startYear);
+  const endYear = getStreamEndYear(stream, assumptions, linkedAsset);
+  let pv = 0;
+  for (let y = startYear; y <= endYear; y++) {
+    const t = y - startYear;
+    const grown = stream.amount * stream.frequency * Math.pow(1 + stream.growth / 100, t);
+    const discounted = grown / Math.pow(1 + discountRate / 100, t + 1);
+    pv += discounted;
+  }
+  return {
+    gross: pv,
+    net: pv * (1 - stream.taxRate / 100)
+  };
+}
+
+export function generateIncomeTimeline(sources, years, assumptions, assetsList = []) {
+  const startYear = new Date().getFullYear();
+  const timeline = Array.from({ length: years }, (_, i) => ({ year: startYear + i, gross: 0, net: 0 }));
+  sources.forEach(s => {
+    if (!s.active) return;
+    const linkedAsset = findLinkedAsset(s.linkedAssetId, assetsList);
+    const start = Math.max(startYear, s.startYear);
+    const end = getStreamEndYear(s, assumptions, linkedAsset);
+    for (let y = start; y <= end; y++) {
+      const idx = y - startYear;
+      if (idx >= 0 && idx < years) {
+        const t = y - start;
+        const grown = s.amount * s.frequency * Math.pow(1 + s.growth / 100, t);
+        timeline[idx].gross += grown;
+        timeline[idx].net += grown * (1 - s.taxRate / 100);
+      }
+    }
+  });
+  return timeline;
+}
+
+import { getStreamEndYear } from '../../utils/incomeProjection';

--- a/src/utils/incomeProjection.js
+++ b/src/utils/incomeProjection.js
@@ -1,16 +1,16 @@
 export function getStreamEndYear(stream, assumptions = {}, linkedAsset) {
   if (stream.endYear != null) return stream.endYear
   if (linkedAsset?.saleYear) return linkedAsset.saleYear
-
+  if (linkedAsset?.maturityYear) return linkedAsset.maturityYear
   switch (stream.type) {
     case 'Salary':
       return assumptions.retirementAge
     case 'Rental':
       return assumptions.deathAge
     case 'Bond':
-      return linkedAsset?.saleYear || linkedAsset?.maturityYear || assumptions.deathAge
+      return linkedAsset?.maturityYear || assumptions.deathAge
     case 'Dividend':
-      return linkedAsset?.saleYear || assumptions.deathAge
+      return assumptions.deathAge
     default:
       return assumptions.retirementAge
   }


### PR DESCRIPTION
## Summary
- compute PV for income streams with net and gross values
- show liquidity coverage and shortfall warnings in Income tab
- display net and gross income lines in timeline chart
- trim stream projections by linked asset sale/maturity
- update tests for new income PV logic

## Testing
- `npm run lint`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6850062e13148323bede95f1627dc7d6