### PR TITLE
Fix Income timeline and remove dashboard

### DIFF
--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -15,7 +15,6 @@ import { useFinance } from '../../FinanceContext'
 import LTCMA from '../../ltcmaAssumptions'
 import InvestmentStrategies from '../../investmentStrategies'
 import { formatCurrency } from '../../utils/formatters'
-import AdequacyAlert from '../../AdequacyAlert'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 
@@ -489,7 +488,6 @@ export default function BalanceSheetTab() {
           </ResponsiveContainer>
         </div>
       </div>
-      <AdequacyAlert />
     </div>
   )
 }

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -14,9 +14,6 @@ import { useFinance } from '../../FinanceContext';
 import { buildIncomeJSON, buildIncomeCSV, submitProfile } from '../../utils/exportHelpers'
 import { calculatePV, generateIncomeTimeline, findLinkedAsset } from './helpers';
 import calcDiscretionaryAdvice from '../../utils/discretionaryUtils';
-import generateLoanAdvice from '../../utils/loanAdvisoryEngine'
-import suggestLoanStrategies from '../../utils/suggestLoanStrategies'
-import AdviceDashboard from '../../AdviceDashboard'
 import IncomeSourceRow from './IncomeSourceRow'
 import IncomeTimelineChart from './IncomeTimelineChart'
 
@@ -29,11 +26,9 @@ export default function IncomeTab() {
     incomeSources, setIncomeSources,
     monthlyExpense,
     monthlySurplusNominal,
-    monthlyIncomeNominal,
     profile,
     settings,
     expensesList,
-    liabilitiesList,
     assetsList,
     setIncomePV,
   } = useFinance();
@@ -82,11 +77,11 @@ export default function IncomeTab() {
     () =>
       generateIncomeTimeline(
         incomeSources,
-        years,
-        assumptions,
-        assetsList
-      ).map(r => ({ ...r, expenses: monthlyExpense * 12 })),
-    [incomeSources, years, assumptions, assetsList, monthlyExpense]
+        { ...assumptions, annualExpenses: monthlyExpense * 12 },
+        assetsList,
+        years
+      ),
+    [incomeSources, assumptions, assetsList, years, monthlyExpense]
   )
 
   const gaps = useMemo(
@@ -111,23 +106,6 @@ export default function IncomeTab() {
     [liquidAssets, monthlyExpense]
   )
 
-  const loanAdvice = useMemo(
-    () =>
-      generateLoanAdvice(
-        liabilitiesList,
-        { ...profile, totalPV: totalGrossPV },
-        monthlyIncomeNominal,
-        monthlyExpense,
-        discountRate,
-        years
-      ),
-    [liabilitiesList, profile, totalGrossPV, monthlyIncomeNominal, monthlyExpense, discountRate, years]
-  );
-
-  const loanStrategies = useMemo(
-    () => suggestLoanStrategies(liabilitiesList),
-    [liabilitiesList]
-  );
 
 
   const stabilityScore = useMemo(() => {
@@ -295,11 +273,6 @@ export default function IncomeTab() {
   // --- Render ---
   return (
     <div className="space-y-8">
-      <AdviceDashboard
-        advice={loanAdvice}
-        discretionaryAdvice={discretionaryAdvice}
-        loanStrategies={loanStrategies}
-      />
       {/* Income Streams Form */}
       <section>
         <h2 className="text-xl font-bold text-amber-700 mb-4">Income Sources</h2>

--- a/src/components/Income/IncomeTimelineChart.jsx
+++ b/src/components/Income/IncomeTimelineChart.jsx
@@ -1,19 +1,19 @@
 import React from 'react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import { BarChart, Bar, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
 
 export default function IncomeTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <LineChart data={data} width={1000} height={500} role="img" aria-label="Income timeline chart">
+    <BarChart data={data} width={1000} height={500} role="img" aria-label="Income timeline chart">
       <XAxis dataKey="year" />
       <YAxis />
       <Tooltip formatter={format} />
       <Legend />
-      <Line dataKey="gross" stroke="#f59e0b" name="Gross Income" />
-      <Line dataKey="net" stroke="#16a34a" name="After Tax" />
-      <Line dataKey="expenses" stroke="#ef4444" name="Expenses" strokeWidth={2} />
-    </LineChart>
+      <Bar dataKey="gross" stackId="a" fill="#f59e0b" name="Gross Income" />
+      <Bar dataKey="net" stackId="a" fill="#16a34a" name="After Tax" />
+      <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" />
+    </BarChart>
   )
 }

--- a/src/components/Income/helpers.js
+++ b/src/components/Income/helpers.js
@@ -18,16 +18,26 @@ export function calculatePV(stream, discountRate, years, assumptions, linkedAsse
   };
 }
 
-export function generateIncomeTimeline(sources, years, assumptions, assetsList = []) {
-  const startYear = new Date().getFullYear();
-  const timeline = Array.from({ length: years }, (_, i) => ({ year: startYear + i, gross: 0, net: 0 }));
+export function generateIncomeTimeline(sources, assumptions, assetsList = [], years) {
+  const timeline = [];
+  const currentYear = new Date().getFullYear();
+  for (let y = 0; y < years; y++) {
+    timeline.push({
+      year: currentYear + y,
+      gross: 0,
+      net: 0,
+      expenses: assumptions.annualExpenses || 0,
+    });
+  }
+
   sources.forEach(s => {
     if (!s.active) return;
-    const linkedAsset = findLinkedAsset(s.linkedAssetId, assetsList);
-    const start = Math.max(startYear, s.startYear);
+    const linkedAsset = assetsList.find(a => a.id === s.linkedAssetId);
+    const start = Math.max(currentYear, s.startYear);
     const end = getStreamEndYear(s, assumptions, linkedAsset);
+
     for (let y = start; y <= end; y++) {
-      const idx = y - startYear;
+      const idx = y - currentYear;
       if (idx >= 0 && idx < years) {
         const t = y - start;
         const grown = s.amount * s.frequency * Math.pow(1 + s.growth / 100, t);
@@ -36,6 +46,7 @@ export function generateIncomeTimeline(sources, years, assumptions, assetsList =
       }
     }
   });
+
   return timeline;
 }
 

--- a/src/utils/incomeProjection.js
+++ b/src/utils/incomeProjection.js
@@ -1,5 +1,5 @@
 export function getStreamEndYear(stream, assumptions = {}, linkedAsset) {
-  if (stream.endYear != null) return stream.endYear
+  if (stream.endYear) return stream.endYear
   if (linkedAsset?.saleYear) return linkedAsset.saleYear
   if (linkedAsset?.maturityYear) return linkedAsset.maturityYear
   switch (stream.type) {
@@ -8,9 +8,7 @@ export function getStreamEndYear(stream, assumptions = {}, linkedAsset) {
     case 'Rental':
       return assumptions.deathAge
     case 'Bond':
-      return linkedAsset?.maturityYear || assumptions.deathAge
-    case 'Dividend':
-      return assumptions.deathAge
+      return linkedAsset?.maturityYear || assumptions.retirementAge
     default:
       return assumptions.retirementAge
   }


### PR DESCRIPTION
## Summary
- drop broken advice dashboard and ribbons
- show stacked bar chart for income timeline
- generate income timeline with expenses field
- update income stream end year logic

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68500bef3ce883238718ec846c3fcf2d