### PR TITLE
Add cashflow timeline and advisor alerts

### DIFF
--- a/src/__tests__/exportHelpers.test.js
+++ b/src/__tests__/exportHelpers.test.js
@@ -19,7 +19,7 @@ test('income CSV includes profile header', () => {
 
 test('plan JSON payload contains profile fields', () => {
   const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
-  const payload = buildPlanJSON(profile, 5, 20, [], 0, [], 0, [], 0, 0)
+  const payload = buildPlanJSON(profile, 5, 20, [], 0, [], 0, [], 0, 0, [])
   expect(payload.profile.email).toBe('test@example.com')
   expect(payload.profile.phone).toBe('555-1234')
   expect(payload.profile.residentialAddress).toBe('123 St')

--- a/src/components/ExpensesGoals/CashflowTimelineChart.jsx
+++ b/src/components/ExpensesGoals/CashflowTimelineChart.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { BarChart, Bar, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import { formatCurrency } from '../../utils/formatters'
+
+export default function CashflowTimelineChart({ data = [], locale, currency }) {
+  const format = v => formatCurrency(v, locale, currency)
+  return (
+    <BarChart data={data} width={1000} height={500} role="img" aria-label="Cashflow timeline chart">
+      <XAxis dataKey="year" />
+      <YAxis />
+      <Tooltip formatter={format} />
+      <Legend />
+      <Bar dataKey="income" stackId="a" fill="#f59e0b" name="Income" />
+      <Bar dataKey="expenses" stackId="a" fill="#dc2626" name="Expenses" />
+      <Bar dataKey="goals" stackId="a" fill="#6b21a8" name="Goals" />
+      <Bar dataKey="loans" stackId="a" fill="#2563eb" name="Loans" />
+      <Line type="monotone" dataKey="netCashflow" stroke="#16a34a" name="Net Cashflow" />
+    </BarChart>
+  )
+}

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -35,7 +35,7 @@ export function buildIncomeCSV(profile, columns = [], rows = []) {
   return header + '\n' + data
 }
 
-export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pvExpenses, goalsList, pvGoals, liabilities, totalLiabilitiesPV, totalRequired) {
+export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pvExpenses, goalsList, pvGoals, liabilities, totalLiabilitiesPV, totalRequired, timeline = []) {
   return {
     generatedAt: new Date().toISOString(),
     profile,
@@ -50,6 +50,7 @@ export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pv
     }),
     totalLiabilitiesPV,
     totalRequired,
+    timeline,
   }
 }
 


### PR DESCRIPTION
## Summary
- add cashflow timeline chart component
- compute timeline in Expenses & Goals tab and export with plan
- show warnings for negative net cashflow
- update export helpers and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685043dd14d08323a2a8a3082b4b9723