### PR TITLE
Enhance expenses & goals timeline

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -47,6 +47,10 @@ export function FinanceProvider({ children }) {
   })
   const [incomePV, setIncomePV]             = useState(0)
   const [expensesPV, setExpensesPV]         = useState(0)
+  const [goalsPV, setGoalsPV]               = useState(() => {
+    const s = storage.get('goalsPV')
+    return s ? parseFloat(s) : 0
+  })
   const [pvExpenses, setPvExpenses]         = useState(0)
   const [monthlyPVExpense, setMonthlyPVExpense] = useState(0)
   const [monthlySurplusNominal, setMonthlySurplusNominal] = useState(() => {
@@ -895,6 +899,8 @@ export function FinanceProvider({ children }) {
 
     const pvE = storage.get('pvExpenses')
     if (pvE) setPvExpenses(+pvE)
+    const gpv = storage.get('goalsPV')
+    if (gpv) setGoalsPV(+gpv)
     const mpvE = storage.get('monthlyPVExpense')
     if (mpvE) setMonthlyPVExpense(+mpvE)
     const ms = storage.get('monthlySurplusNominal')
@@ -938,6 +944,7 @@ export function FinanceProvider({ children }) {
       monthlyExpense, setMonthlyExpense,
       incomePV,     setIncomePV,
       expensesPV,   setExpensesPV,
+      goalsPV,      setGoalsPV,
       pvExpenses,
       monthlyPVExpense,
       pvHigh,

--- a/src/components/ExpensesGoals/CashflowTimelineChart.jsx
+++ b/src/components/ExpensesGoals/CashflowTimelineChart.jsx
@@ -14,7 +14,7 @@ export default function CashflowTimelineChart({ data = [], locale, currency }) {
       <Bar dataKey="expenses" stackId="a" fill="#dc2626" name="Expenses" />
       <Bar dataKey="goals" stackId="a" fill="#6b21a8" name="Goals" />
       <Bar dataKey="loans" stackId="a" fill="#2563eb" name="Loans" />
-      <Line type="monotone" dataKey="netCashflow" stroke="#16a34a" name="Net Cashflow" />
+      <Line dataKey="net" stroke="#16a34a" name="Net" />
     </BarChart>
   )
 }


### PR DESCRIPTION
## Summary
- validate start and end year editing on Expenses & Goals
- default items span five years
- compute cashflow timeline with net column
- show warnings for shortfalls and post‑retirement loans
- sync PV totals with Balance Sheet via context
- include net series in timeline chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68512bb8e244832381b7d54708f68e81