### PR TITLE
Refactor Expenses & Goals layout

### DIFF
--- a/src/components/ExpensesGoals/CashflowTimelineChart.jsx
+++ b/src/components/ExpensesGoals/CashflowTimelineChart.jsx
@@ -1,20 +1,20 @@
 import React from 'react'
-import { BarChart, Bar, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
 export default function CashflowTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <BarChart data={data} width={1000} height={500} role="img" aria-label="Cashflow timeline chart">
+    <LineChart data={data} width={1000} height={400} role="img" aria-label="Cashflow timeline chart">
       <XAxis dataKey="year" />
-      <YAxis />
+      <YAxis tickFormatter={format} />
       <Tooltip formatter={format} />
       <Legend />
-      <Bar dataKey="income" stackId="a" fill="#f59e0b" name="Income" />
-      <Bar dataKey="expenses" stackId="a" fill="#dc2626" name="Expenses" />
-      <Bar dataKey="goals" stackId="a" fill="#6b21a8" name="Goals" />
-      <Bar dataKey="loans" stackId="a" fill="#2563eb" name="Loans" />
-      <Line dataKey="net" stroke="#16a34a" name="Net" />
-    </BarChart>
+      <Line type="monotone" dataKey="income" stroke="#22c55e" name="Income" />
+      <Line type="monotone" dataKey="expenses" stroke="#dc2626" name="Expenses" />
+      <Line type="monotone" dataKey="goals" stroke="#6b21a8" name="Goals" />
+      <Line type="monotone" dataKey="loans" stroke="#2563eb" name="Loans" />
+      <Line type="monotone" dataKey="net" stroke="#f59e0b" name="Net" />
+    </LineChart>
   )
 }

--- a/src/components/common/Card.jsx
+++ b/src/components/common/Card.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+
+export function Card({ children, className = '', ...props }) {
+  return (
+    <div className={`shadow rounded-xl p-4 bg-white ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export function CardHeader({ children, className = '', ...props }) {
+  return (
+    <div className={`flex justify-between items-center mb-2 ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}
+
+export function CardBody({ children, className = '', ...props }) {
+  return (
+    <div className={className} {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/selectors/timeline.js
+++ b/src/selectors/timeline.js
@@ -1,0 +1,28 @@
+export default function buildTimeline(minYear, maxYear, incomeFn, expensesList, goalsList, getLoansForYear = () => 0) {
+  const timeline = []
+  for (let y = minYear; y <= maxYear; y++) {
+    const income = typeof incomeFn === 'function' ? incomeFn(y) : 0
+    let expenses = 0
+    let goals = 0
+    let loans = getLoansForYear(y)
+
+    expensesList.forEach(e => {
+      if (y >= e.startYear && y <= e.endYear) {
+        const t = y - e.startYear
+        const freq = e.paymentsPerYear || e.frequency || 1
+        const growth = e.growth || 0
+        expenses += (Number(e.amount) || 0) * freq * Math.pow(1 + growth / 100, t)
+      }
+    })
+
+    goalsList.forEach(g => {
+      if (y >= g.startYear && y <= g.endYear) {
+        goals += Number(g.amount) || 0
+      }
+    })
+
+    const net = income - expenses - goals - loans
+    timeline.push({ year: y, income, expenses, goals, loans, net })
+  }
+  return timeline
+}


### PR DESCRIPTION
## Summary
- add generic Card component
- convert timeline chart to line chart
- move timeline calculations into reusable selector
- simplify Expenses & Goals tab using cards and advisor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685130861afc83239f6930c47dc91979