### PR TITLE
Improve expenses timeline chart

### DIFF
--- a/src/components/ExpensesGoals/CashflowTimelineChart.jsx
+++ b/src/components/ExpensesGoals/CashflowTimelineChart.jsx
@@ -1,20 +1,17 @@
 import React from 'react'
-import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import { AreaChart, Area, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
 export default function CashflowTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <LineChart data={data} width={1000} height={400} role="img" aria-label="Cashflow timeline chart">
+    <AreaChart data={data} width={1000} height={400} role="img" aria-label="Cashflow timeline chart">
       <XAxis dataKey="year" />
       <YAxis tickFormatter={format} />
       <Tooltip formatter={format} />
       <Legend />
-      <Line type="monotone" dataKey="income" stroke="#22c55e" name="Income" />
-      <Line type="monotone" dataKey="expenses" stroke="#dc2626" name="Expenses" />
-      <Line type="monotone" dataKey="goals" stroke="#6b21a8" name="Goals" />
-      <Line type="monotone" dataKey="loans" stroke="#2563eb" name="Loans" />
+      <Area type="monotone" dataKey="surplus" stroke="#22c55e" fill="#bbf7d0" name="Surplus" />
       <Line type="monotone" dataKey="net" stroke="#f59e0b" name="Net" />
-    </LineChart>
+    </AreaChart>
   )
 }

--- a/src/selectors/timeline.js
+++ b/src/selectors/timeline.js
@@ -1,10 +1,19 @@
-export default function buildTimeline(minYear, maxYear, incomeFn, expensesList, goalsList, getLoansForYear = () => 0) {
+export default function buildTimeline(
+  minYear,
+  maxYear,
+  incomeFn,
+  expensesList,
+  goalsList,
+  getLoansForYear = () => 0
+) {
   const timeline = []
+  let prevSurplus = 0
+
   for (let y = minYear; y <= maxYear; y++) {
     const income = typeof incomeFn === 'function' ? incomeFn(y) : 0
     let expenses = 0
     let goals = 0
-    let loans = getLoansForYear(y)
+    const loans = getLoansForYear(y)
 
     expensesList.forEach(e => {
       if (y >= e.startYear && y <= e.endYear) {
@@ -22,7 +31,10 @@ export default function buildTimeline(minYear, maxYear, incomeFn, expensesList, 
     })
 
     const net = income - expenses - goals - loans
-    timeline.push({ year: y, income, expenses, goals, loans, net })
+    const surplus = prevSurplus + net
+    timeline.push({ year: y, income, expenses, goals, loans, net, surplus })
+    prevSurplus = surplus
   }
+
   return timeline
 }


### PR DESCRIPTION
## Summary
- compute cumulative surplus in `buildTimeline`
- swap to area/line chart showing surplus & net
- validate amounts and confirm deletes
- simplify advisor panel with deficit check and peak surplus
- update PV orchestration and export JSON

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851349ecfb08323a400a4c1f72adecc