### PR TITLE
Add range helper for int fields

### DIFF
--- a/src/__tests__/expenseGoalSchemas.priority.test.js
+++ b/src/__tests__/expenseGoalSchemas.priority.test.js
@@ -1,0 +1,26 @@
+import { expenseItemSchema } from '../schemas/expenseGoalSchemas.js'
+
+test('valid priority between 1 and 3 passes', () => {
+  const data = {
+    name: 'Rent',
+    amount: 100,
+    paymentsPerYear: 1,
+    startYear: 2024,
+    priority: 3,
+  }
+  const parsed = expenseItemSchema.safeParse(data)
+  expect(parsed.success).toBe(true)
+  expect(parsed.data.priority).toBe(3)
+})
+
+test('priority outside range fails validation', () => {
+  const data = {
+    name: 'Rent',
+    amount: 100,
+    paymentsPerYear: 1,
+    startYear: 2024,
+    priority: 5,
+  }
+  const parsed = expenseItemSchema.safeParse(data)
+  expect(parsed.success).toBe(false)
+})

--- a/src/schemas/expenseGoalSchemas.js
+++ b/src/schemas/expenseGoalSchemas.js
@@ -15,6 +15,10 @@ export const nonNegNumber = () =>
 
 export const intField = () => z.preprocess(toInt, z.number().int())
 
+// New helper to enforce integer range in a single preprocess step
+export const intFieldWithRange = (min, max) =>
+  z.preprocess(toInt, z.number().int().min(min).max(max))
+
 export const posIntField = () => z.preprocess(toInt, z.number().int().positive())
 
 export const expenseItemSchema = z
@@ -24,7 +28,7 @@ export const expenseItemSchema = z
     paymentsPerYear: posIntField(),
     growth: numField().default(0),
     category: z.string().default(''),
-    priority: intField().min(1).max(3).default(2),
+    priority: intFieldWithRange(1, 3).default(2),
     startYear: intField(),
     endYear: intField().optional().nullable(),
   })


### PR DESCRIPTION
## Summary
- add an `intFieldWithRange` schema helper to allow ranged integers
- use new helper for expense priority
- verify priority validation with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851549a276c832392cf9abe1df93556