### PR TITLE
Add liabilities input and export

### DIFF
--- a/src/__tests__/exportHelpers.test.js
+++ b/src/__tests__/exportHelpers.test.js
@@ -27,7 +27,7 @@ test('plan JSON payload contains profile fields', () => {
 
 test('plan CSV includes profile header', () => {
   const profile = { email:'test@example.com', phone:'555-1234', residentialAddress:'123 St' }
-  const csv = buildPlanCSV(profile, [{ category:'Expenses', value:100 }])
+  const csv = buildPlanCSV(profile, [{ category:'Expenses', value:100 }], [])
   expect(csv).toContain('test@example.com')
   expect(csv).toContain('555-1234')
   expect(csv).toContain('123 St')

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -44,17 +44,14 @@ export function buildPlanJSON(profile, discountRate, lifeYears, expensesList, pv
     pvExpenses,
     goals: goalsList,
     pvGoals,
-    liabilities: liabilities.map(l => {
-      const { schedule: _schedule, ...rest } = l
-      return rest
-    }),
+    liabilities,
     totalLiabilitiesPV,
     totalRequired,
     timeline,
   }
 }
 
-export function buildPlanCSV(profile, pvSummaryData = []) {
+export function buildPlanCSV(profile, pvSummaryData = [], loans = []) {
   const headerRows = [
     ['Name', profile.name || ''],
     ['Email', profile.email || ''],
@@ -64,8 +61,22 @@ export function buildPlanCSV(profile, pvSummaryData = []) {
   const header = headerRows.map(r => r.map(quoteCSV).join(',')).join('\n')
   const columns = ['Category', 'Value']
   const rows = pvSummaryData.map(d => [d.category, d.value])
-  const data = buildCSV(columns, rows)
-  return header + '\n' + data
+  const summary = buildCSV(columns, rows)
+
+  let loanSection = ''
+  if (Array.isArray(loans) && loans.length > 0) {
+    const loanCols = ['Loan Name', 'Principal', 'Rate', 'Term', 'Payment']
+    const loanRows = loans.map(l => [
+      l.name || 'Loan',
+      l.principal,
+      l.interestRate,
+      l.termYears,
+      l.computedPayment,
+    ])
+    loanSection = '\n' + buildCSV(loanCols, loanRows)
+  }
+
+  return header + '\n' + summary + loanSection
 }
 
 export async function submitProfile(payload = {}, settings = {}) {


### PR DESCRIPTION
## Summary
- allow editing liabilities in the expenses/goals tab
- compute payment schedules using loan helpers
- include loans in exports

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685155b26ea483239029fdc93f407aaf