### PR TITLE
Add assumptions modal with footer disclaimer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -41,6 +41,9 @@ export default function App() {
           </Suspense>
         </main>
       </div>
+      <footer className="text-center text-xs text-gray-600 bg-gray-100 py-2">
+        Projections are for illustrative purposes only.
+      </footer>
     </div>
   )
 }

--- a/src/components/AssumptionsModal.jsx
+++ b/src/components/AssumptionsModal.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useFinance } from '../FinanceContext'
+
+export default function AssumptionsModal({ open, onClose }) {
+  const { settings } = useFinance()
+  if (!open) return null
+  const items = [
+    { label: 'Inflation Rate', value: `${settings.inflationRate}%` },
+    { label: 'Discount Rate', value: `${settings.discountRate}%` },
+    { label: 'Expected Return', value: `${settings.expectedReturn}%` },
+    { label: 'Retirement Age', value: settings.retirementAge },
+  ]
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white rounded-lg shadow p-6 w-80" role="dialog" aria-modal="true" aria-label="Assumptions">
+        <h2 className="text-lg font-semibold mb-4 text-amber-700">Assumptions</h2>
+        <ul className="space-y-1 mb-4">
+          {items.map(it => (
+            <li key={it.label} className="flex justify-between">
+              <span className="text-slate-600">{it.label}</span>
+              <span className="font-medium">{it.value}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="text-right">
+          <button onClick={onClose} className="border border-amber-600 px-4 py-1 rounded hover:bg-amber-50">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -12,6 +12,7 @@ import { ResponsiveContainer } from 'recharts'
 import CashflowTimelineChart from './CashflowTimelineChart'
 import buildTimeline from '../../selectors/timeline'
 import { Card, CardHeader, CardBody } from '../common/Card.jsx'
+import AssumptionsModal from '../AssumptionsModal.jsx'
 
 /**
  * ExpensesGoalsTab
@@ -44,6 +45,7 @@ export default function ExpensesGoalsTab() {
   const [showExpenses, setShowExpenses] = useState(true)
   const [showGoals, setShowGoals] = useState(true)
   const [showLiabilities, setShowLiabilities] = useState(true)
+  const [showAssumptions, setShowAssumptions] = useState(false)
   const [expenseErrors, setExpenseErrors] = useState({})
   const [goalErrors, setGoalErrors] = useState({})
 
@@ -538,7 +540,15 @@ export default function ExpensesGoalsTab() {
       </section>
 
       <div className="text-right">
-        <button onClick={exportJSON} className="mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500" aria-label="Export to JSON" title="Export to JSON">
+        <button
+          onClick={() => setShowAssumptions(true)}
+          className="mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="View assumptions"
+          title="View assumptions"
+        >
+          ℹ️ Assumptions
+        </button>
+        <button onClick={exportJSON} className="ml-2 mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500" aria-label="Export to JSON" title="Export to JSON">
           📁 Export to JSON
         </button>
         <button onClick={exportCSV} className="ml-2 mt-4 border border-amber-600 px-4 py-2 rounded-md hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500" aria-label="Export to CSV" title="Export to CSV">
@@ -548,6 +558,7 @@ export default function ExpensesGoalsTab() {
           🚀 Submit to API
         </button>
       </div>
+      <AssumptionsModal open={showAssumptions} onClose={() => setShowAssumptions(false)} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- create `AssumptionsModal` component
- add footer disclosure banner
- show an Assumptions button on the Expenses & Goals tab

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516267bc248323bf9df8ddc4b13656