### PR TITLE
Implement local audit log tracking

### DIFF
--- a/src/components/AuditLogView.jsx
+++ b/src/components/AuditLogView.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react'
+import storage from '../utils/storage'
+import { buildCSV } from '../utils/csvUtils'
+import { readAuditLog } from '../utils/auditLog'
+import { Card, CardHeader, CardBody } from './common/Card.jsx'
+
+export default function AuditLogView() {
+  const [log, setLog] = useState(() => readAuditLog(storage))
+
+  useEffect(() => {
+    const unsub = storage.subscribe('auditLog', val => {
+      try {
+        setLog(val ? JSON.parse(val) : [])
+      } catch {
+        setLog([])
+      }
+    })
+    return unsub
+  }, [])
+
+  const exportCSV = () => {
+    const columns = ['Timestamp', 'Field', 'Old Value', 'New Value']
+    const rows = log.map(entry => [entry.ts, entry.field, entry.oldValue, entry.newValue])
+    const csv = buildCSV(columns, rows)
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'audit-log.csv'
+    a.click()
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-xl font-bold text-amber-700">Edit Audit Log</h2>
+        <button
+          onClick={exportCSV}
+          className="border border-amber-600 px-2 py-1 rounded-md text-sm hover:bg-amber-50"
+        >
+          Export CSV
+        </button>
+      </CardHeader>
+      <CardBody>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="text-left p-1">Timestamp</th>
+                <th className="text-left p-1">Field</th>
+                <th className="text-left p-1">Old</th>
+                <th className="text-left p-1">New</th>
+              </tr>
+            </thead>
+            <tbody>
+              {log.map((e, i) => (
+                <tr key={i} className="border-b last:border-none">
+                  <td className="p-1">{e.ts}</td>
+                  <td className="p-1">{e.field}</td>
+                  <td className="p-1">{String(e.oldValue)}</td>
+                  <td className="p-1">{String(e.newValue)}</td>
+                </tr>
+              ))}
+              {log.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="p-2 italic text-center text-slate-500">
+                    No edits logged
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardBody>
+    </Card>
+  )
+}

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -15,6 +15,8 @@ import { useFinance } from '../../FinanceContext'
 import LTCMA from '../../ltcmaAssumptions'
 import InvestmentStrategies from '../../investmentStrategies'
 import { formatCurrency } from '../../utils/formatters'
+import storage from '../../utils/storage'
+import { appendAuditLog } from '../../utils/auditLog'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 
@@ -158,6 +160,7 @@ export default function BalanceSheetTab() {
   }
 
   const updateItem = (setList, list, index, field, value) => {
+    const oldValue = list[index]?.[field]
     const updatedItem = {
       ...list[index],
       [field]:
@@ -172,6 +175,12 @@ export default function BalanceSheetTab() {
     const updated = list.map((it, i) => (i === index ? updatedItem : it))
     if (setList === setAssetsList && !validateAsset(updatedItem, index, list)) return
     setList(updated)
+    const prefix = setList === setAssetsList ? 'asset' : 'liability'
+    appendAuditLog(storage, {
+      field: `${prefix}.${field}`,
+      oldValue,
+      newValue: updatedItem[field],
+    })
   }
 
   const toggleAsset = id =>

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -7,6 +7,7 @@ import { calculateLoanSchedule } from '../../modules/loan/loanCalculator.js'
 import { presentValue } from '../../modules/loan/presentValue.js'
 import { buildPlanJSON, buildPlanCSV, submitProfile } from '../../utils/exportHelpers'
 import storage from '../../utils/storage'
+import { appendAuditLog } from '../../utils/auditLog'
 import { expenseItemSchema, goalItemSchema } from '../../schemas/expenseGoalSchemas.js'
 import { ResponsiveContainer } from 'recharts'
 import CashflowTimelineChart from './CashflowTimelineChart'
@@ -54,6 +55,7 @@ export default function ExpensesGoalsTab() {
   // --- CRUD Handlers ---
   // Expenses
   const handleExpenseChange = (i, field, raw) => {
+    const oldValue = expensesList[i]?.[field]
     setExpensesList(prev => {
       const next = [...prev]
       const updated = { ...next[i], [field]: raw }
@@ -69,6 +71,11 @@ export default function ExpensesGoalsTab() {
         }))
       }
       return next
+    })
+    appendAuditLog(storage, {
+      field: `expense.${field}`,
+      oldValue,
+      newValue: raw,
     })
   }
   const addExpense = () => {
@@ -95,6 +102,7 @@ export default function ExpensesGoalsTab() {
 
   // Goals
   const handleGoalChange = (i, field, raw) => {
+    const oldValue = goalsList[i]?.[field]
     setGoalsList(prev => {
       const next = [...prev]
       const updated = { ...next[i], [field]: raw }
@@ -110,6 +118,11 @@ export default function ExpensesGoalsTab() {
         }))
       }
       return next
+    })
+    appendAuditLog(storage, {
+      field: `goal.${field}`,
+      oldValue,
+      newValue: raw,
     })
   }
   const addGoal = () => {
@@ -132,10 +145,16 @@ export default function ExpensesGoalsTab() {
 
   // Liabilities (Loans)
   const handleLiabilityChange = (i, field, value) => {
+    const oldValue = liabilitiesList[i]?.[field]
     setLiabilitiesList(prev => {
       const next = [...prev]
       next[i] = { ...next[i], [field]: value }
       return next
+    })
+    appendAuditLog(storage, {
+      field: `liability.${field}`,
+      oldValue,
+      newValue: value,
     })
   }
   const addLiability = () => {

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -19,6 +19,7 @@ import IncomeTimelineChart from './IncomeTimelineChart'
 
 import { formatCurrency } from '../../utils/formatters'
 import storage from '../../utils/storage'
+import { appendAuditLog } from '../../utils/auditLog'
 
 
 export default function IncomeTab() {
@@ -148,6 +149,7 @@ export default function IncomeTab() {
 
   // --- Handlers for form inputs ---
   const onFieldChange = (idx, field, raw) => {
+    const oldValue = incomeSources[idx]?.[field]
     const updated = incomeSources.map((src, i) => {
       if (i !== idx) return src
       if (field === 'name' || field === 'type') {
@@ -176,6 +178,11 @@ export default function IncomeTab() {
       return { ...src, [field]: isNaN(num) ? 0 : Math.max(0, num) }
     })
     setIncomeSources(updated)
+    appendAuditLog(storage, {
+      field: `income.${field}`,
+      oldValue,
+      newValue: updated[idx]?.[field],
+    })
   }
 
   const addIncome = () => {

--- a/src/components/Profile/ProfileTab.jsx
+++ b/src/components/Profile/ProfileTab.jsx
@@ -1,6 +1,8 @@
 // src/ProfileTab.jsx
 import React, { useState, useEffect } from 'react'
 import { useFinance } from '../../FinanceContext'
+import storage from '../../utils/storage'
+import { appendAuditLog } from '../../utils/auditLog'
 
 export default function ProfileTab() {
   const { profile, updateProfile, riskScore } = useFinance()
@@ -14,6 +16,11 @@ export default function ProfileTab() {
   // Handle any field change locally, then persist via context
   const handleChange = (field, value) => {
     const updated = { ...form, [field]: value }
+    appendAuditLog(storage, {
+      field: `profile.${field}`,
+      oldValue: form[field],
+      newValue: value,
+    })
 
     if (field === 'lifeExpectancy' && value <= updated.age) {
       updated.lifeExpectancy = updated.age + 1

--- a/src/utils/auditLog.js
+++ b/src/utils/auditLog.js
@@ -1,0 +1,18 @@
+export function readAuditLog(storage) {
+  try {
+    const raw = storage.get('auditLog')
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+export function appendAuditLog(storage, entry = {}) {
+  const log = readAuditLog(storage)
+  log.push({ ts: new Date().toISOString(), ...entry })
+  try {
+    storage.set('auditLog', JSON.stringify(log))
+  } catch (err) {
+    console.error('Failed to write audit log', err)
+  }
+}


### PR DESCRIPTION
## Summary
- add `AuditLogView` component for viewing and exporting the edit audit log
- add storage helpers in `utils/auditLog.js`
- log profile, income, expenses, goal, liability and balance sheet edits

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851647bcb24832381b7e8c25640af9e