### PR TITLE
Prefill financial entries from profile horizon

### DIFF
--- a/src/__tests__/expensesGoals.pvUpdate.test.js
+++ b/src/__tests__/expensesGoals.pvUpdate.test.js
@@ -32,7 +32,9 @@ test('adding an expense updates PV totals', async () => {
   const amtInput = screen.getByTitle('Expense amount')
   fireEvent.change(amtInput, { target: { value: '100' } })
 
-  const expectedVal = formatCurrency(100 * 12 * 6, 'en-US', 'KES').replace('KES', '')
+  const profile = JSON.parse(localStorage.getItem('profile'))
+  const years = profile.lifeExpectancy - profile.age
+  const expectedVal = formatCurrency(100 * 12 * years, 'en-US', 'KES').replace('KES', '')
   await waitFor(() => {
     expect(valueNode.textContent).toContain(expectedVal.trim())
   })

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -27,8 +27,6 @@ import AssumptionsModal from '../AssumptionsModal.jsx'
  */
 export default function ExpensesGoalsTab() {
   const currentYear = new Date().getFullYear()
-  const defaultStart = currentYear
-  const defaultEnd = currentYear + 5
   const {
     discountRate,
     expensesList, setExpensesList,
@@ -42,6 +40,9 @@ export default function ExpensesGoalsTab() {
     years,
     annualIncome
   } = useFinance()
+  const horizon = Math.max(1, profile.lifeExpectancy - profile.age)
+  const defaultStart = currentYear
+  const defaultEnd = currentYear + horizon
 
   const [showExpenses, setShowExpenses] = useState(true)
   const [showGoals, setShowGoals] = useState(true)
@@ -79,7 +80,6 @@ export default function ExpensesGoalsTab() {
     })
   }
   const addExpense = () => {
-    const now = new Date().getFullYear()
     setExpensesList([
       ...expensesList,
       {
@@ -89,8 +89,8 @@ export default function ExpensesGoalsTab() {
         growth: 0,
         category: 'Fixed',
         priority: 2,
-        startYear: now,
-        endYear: now + 5,
+        startYear: defaultStart,
+        endYear: defaultEnd,
       },
     ])
   }
@@ -132,8 +132,8 @@ export default function ExpensesGoalsTab() {
         name: '',
         amount: 0,
         targetYear: currentYear,
-        startYear: currentYear,
-        endYear: currentYear + 5,
+        startYear: defaultStart,
+        endYear: defaultEnd,
       },
     ])
   }
@@ -167,6 +167,8 @@ export default function ExpensesGoalsTab() {
         termYears: 1,
         paymentsPerYear: 12,
         extraPayment: 0,
+        startYear: defaultStart,
+        endYear: defaultEnd,
       },
     ])
   }


### PR DESCRIPTION
## Summary
- derive default start and end years in ExpensesGoalsTab from profile data
- seed newly added expenses, goals, and liabilities with start and end years
- update expense PV test to use life expectancy horizon

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685173cc5a108323bc3c79f8cf0e1e74