### PR TITLE
Add sanitization utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Personal Finance Planner</title>
     <meta name="description" content="Personal finance tracker for income, expenses, goals, and more." />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -17,6 +17,7 @@ import InvestmentStrategies from '../../investmentStrategies'
 import { formatCurrency } from '../../utils/formatters'
 import storage from '../../utils/storage'
 import { appendAuditLog } from '../../utils/auditLog'
+import sanitize from '../../utils/sanitize'
 
 const COLORS = ['#fbbf24', '#f59e0b', '#fde68a', '#eab308', '#fcd34d', '#fef3c7']
 
@@ -159,7 +160,8 @@ export default function BalanceSheetTab() {
     return true
   }
 
-  const updateItem = (setList, list, index, field, value) => {
+  const updateItem = (setList, list, index, field, raw) => {
+    const value = typeof raw === 'string' ? sanitize(raw) : raw
     const oldValue = list[index]?.[field]
     const updatedItem = {
       ...list[index],

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -8,6 +8,7 @@ import { presentValue } from '../../modules/loan/presentValue.js'
 import { buildPlanJSON, buildPlanCSV, submitProfile } from '../../utils/exportHelpers'
 import storage from '../../utils/storage'
 import { appendAuditLog } from '../../utils/auditLog'
+import sanitize from '../../utils/sanitize'
 import { expenseItemSchema, goalItemSchema } from '../../schemas/expenseGoalSchemas.js'
 import { ResponsiveContainer } from 'recharts'
 import LifetimeStackedChart from './LifetimeStackedChart'
@@ -56,10 +57,11 @@ export default function ExpensesGoalsTab() {
   // --- CRUD Handlers ---
   // Expenses
   const handleExpenseChange = (i, field, raw) => {
+    const value = typeof raw === 'string' ? sanitize(raw) : raw
     const oldValue = expensesList[i]?.[field]
     setExpensesList(prev => {
       const next = [...prev]
-      const updated = { ...next[i], [field]: raw }
+      const updated = { ...next[i], [field]: value }
       const parsed = expenseItemSchema.safeParse(updated)
       if (parsed.success) {
         next[i] = parsed.data
@@ -76,7 +78,7 @@ export default function ExpensesGoalsTab() {
     appendAuditLog(storage, {
       field: `expense.${field}`,
       oldValue,
-      newValue: raw,
+      newValue: value,
     })
   }
   const addExpense = () => {
@@ -102,10 +104,11 @@ export default function ExpensesGoalsTab() {
 
   // Goals
   const handleGoalChange = (i, field, raw) => {
+    const value = typeof raw === 'string' ? sanitize(raw) : raw
     const oldValue = goalsList[i]?.[field]
     setGoalsList(prev => {
       const next = [...prev]
-      const updated = { ...next[i], [field]: raw }
+      const updated = { ...next[i], [field]: value }
       const parsed = goalItemSchema.safeParse(updated)
       if (parsed.success) {
         next[i] = parsed.data
@@ -122,7 +125,7 @@ export default function ExpensesGoalsTab() {
     appendAuditLog(storage, {
       field: `goal.${field}`,
       oldValue,
-      newValue: raw,
+      newValue: value,
     })
   }
   const addGoal = () => {
@@ -144,7 +147,8 @@ export default function ExpensesGoalsTab() {
   }
 
   // Liabilities (Loans)
-  const handleLiabilityChange = (i, field, value) => {
+  const handleLiabilityChange = (i, field, valueRaw) => {
+    const value = typeof valueRaw === 'string' ? sanitize(valueRaw) : valueRaw
     const oldValue = liabilitiesList[i]?.[field]
     setLiabilitiesList(prev => {
       const next = [...prev]

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -20,6 +20,7 @@ import IncomeTimelineChart from './IncomeTimelineChart'
 import { formatCurrency } from '../../utils/formatters'
 import storage from '../../utils/storage'
 import { appendAuditLog } from '../../utils/auditLog'
+import sanitize from '../../utils/sanitize'
 
 
 export default function IncomeTab() {
@@ -149,17 +150,18 @@ export default function IncomeTab() {
 
   // --- Handlers for form inputs ---
   const onFieldChange = (idx, field, raw) => {
+    const value = typeof raw === 'string' ? sanitize(raw) : raw
     const oldValue = incomeSources[idx]?.[field]
     const updated = incomeSources.map((src, i) => {
       if (i !== idx) return src
       if (field === 'name' || field === 'type') {
-        return { ...src, [field]: raw }
+        return { ...src, [field]: value }
       }
       if (field === 'linkedAssetId') {
-        return { ...src, linkedAssetId: raw }
+        return { ...src, linkedAssetId: value }
       }
       if (field === 'active') {
-        return { ...src, active: raw }
+        return { ...src, active: value }
       }
       if (field === 'startYear' || field === 'endYear') {
         const yr = Number(raw)

--- a/src/components/Profile/ProfileTab.jsx
+++ b/src/components/Profile/ProfileTab.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react'
 import { useFinance } from '../../FinanceContext'
 import storage from '../../utils/storage'
+import sanitize from '../../utils/sanitize'
 import { appendAuditLog } from '../../utils/auditLog'
 
 export default function ProfileTab() {
@@ -15,11 +16,12 @@ export default function ProfileTab() {
 
   // Handle any field change locally, then persist via context
   const handleChange = (field, value) => {
-    const updated = { ...form, [field]: value }
+    const clean = typeof value === 'string' ? sanitize(value) : value
+    const updated = { ...form, [field]: clean }
     appendAuditLog(storage, {
       field: `profile.${field}`,
       oldValue: form[field],
-      newValue: value,
+      newValue: clean,
     })
 
     if (field === 'lifeExpectancy' && value <= updated.age) {

--- a/src/tabs/PreferencesTab.jsx
+++ b/src/tabs/PreferencesTab.jsx
@@ -1,6 +1,7 @@
 // src/PreferencesTab.jsx
 import React, { useState, useEffect } from 'react'
 import { useFinance } from '../FinanceContext'
+import sanitize from '../utils/sanitize'
 
 export default function PreferencesTab() {
   const {
@@ -24,7 +25,8 @@ export default function PreferencesTab() {
 
   // Update both local form state and context (which persists to localStorage)
   const handleChange = (field, value) => {
-    const updated = { ...form, [field]: value }
+    const clean = typeof value === 'string' ? sanitize(value) : value
+    const updated = { ...form, [field]: clean }
     setForm(updated)
     updateSettings(updated)
   }

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -1,0 +1,4 @@
+export default function sanitize(str) {
+  if (typeof str !== 'string') return str;
+  return str.replace(/<[^>]*>/g, '');
+}


### PR DESCRIPTION
## Summary
- introduce `sanitize` utility to strip HTML
- sanitize user inputs before storing state
- lock CSP to self in `index.html`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685178336cb8832393021a6186560eaf