### PR TITLE
Add default expenses and goals

### DIFF
--- a/src/__tests__/expensesGoals.defaults.test.js
+++ b/src/__tests__/expensesGoals.defaults.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import ExpensesGoalsTab from '../components/ExpensesGoals/ExpensesGoalsTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function mount() {
+  localStorage.setItem('profile', JSON.stringify({ nationality: 'Kenyan', age: 30, lifeExpectancy: 85 }))
+  function Lengths() {
+    const { expensesList, goalsList } = useFinance()
+    return (
+      <>
+        <div data-testid="exp-count">{expensesList.length}</div>
+        <div data-testid="goal-count">{goalsList.length}</div>
+        <ExpensesGoalsTab />
+      </>
+    )
+  }
+  return render(
+    <FinanceProvider>
+      <Lengths />
+    </FinanceProvider>
+  )
+}
+
+test('defaults populate when lists empty', async () => {
+  mount()
+  expect(localStorage.getItem('expensesList')).not.toBeNull()
+  await screen.findByText(/PV of Expenses/)
+  await waitFor(() => localStorage.getItem('expensesList') !== '[]', { timeout: 2000 })
+  await waitFor(() => localStorage.getItem('goalsList') !== '[]', { timeout: 2000 })
+})
+
+test('defaults not loaded when stored data present', async () => {
+  localStorage.setItem('expensesList', JSON.stringify([
+    { name: 'Gym', amount: 50, paymentsPerYear: 12, startYear: 2024, priority: 1 }
+  ]))
+  mount()
+  await screen.findByText(/PV of Expenses/)
+  await waitFor(() => localStorage.getItem('expensesList')?.includes('Gym'), { timeout: 2000 })
+})

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -15,6 +15,11 @@ import LifetimeStackedChart from './LifetimeStackedChart'
 import buildTimeline from '../../selectors/timeline'
 import { Card, CardHeader, CardBody } from '../common/Card.jsx'
 import AssumptionsModal from '../AssumptionsModal.jsx'
+import {
+  defaultExpenses,
+  defaultGoals,
+  defaultLiabilities,
+} from './defaults.js'
 
 /**
  * ExpensesGoalsTab
@@ -51,6 +56,19 @@ export default function ExpensesGoalsTab() {
   const [showAssumptions, setShowAssumptions] = useState(false)
   const [expenseErrors, setExpenseErrors] = useState({})
   const [goalErrors, setGoalErrors] = useState({})
+
+  // Populate defaults on first mount when no data is present
+  useEffect(() => {
+    if (expensesList.length === 0) {
+      setExpensesList(defaultExpenses(defaultStart, defaultEnd))
+    }
+    if (goalsList.length === 0) {
+      setGoalsList(defaultGoals(defaultStart))
+    }
+    if (liabilitiesList.length === 0) {
+      setLiabilitiesList(defaultLiabilities(defaultStart))
+    }
+  }, [])
 
   // --- Helpers ---
 
@@ -180,6 +198,18 @@ export default function ExpensesGoalsTab() {
     if (window.confirm('Delete this item?')) {
       setLiabilitiesList(liabilitiesList.filter((_, idx) => idx !== i))
     }
+  }
+
+  const clearLists = () => {
+    setExpensesList([])
+    setGoalsList([])
+    setLiabilitiesList([])
+  }
+
+  const resetDefaults = () => {
+    setExpensesList(defaultExpenses(defaultStart, defaultEnd))
+    setGoalsList(defaultGoals(defaultStart))
+    setLiabilitiesList(defaultLiabilities(defaultStart))
   }
 
   // --- 1) Remaining lifetime horizon ---
@@ -374,6 +404,23 @@ export default function ExpensesGoalsTab() {
         )}
         <p>Peak surplus: {formatCurrency(maxSurplus, settings.locale, settings.currency)}</p>
       </Card>
+
+      <div className="text-right space-x-2">
+        <button
+          onClick={clearLists}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Clear lists"
+        >
+          Clear
+        </button>
+        <button
+          onClick={resetDefaults}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Reset lists to defaults"
+        >
+          Reset Defaults
+        </button>
+      </div>
 
 
       <Card className="mb-6">

--- a/src/components/ExpensesGoals/defaults.js
+++ b/src/components/ExpensesGoals/defaults.js
@@ -1,0 +1,51 @@
+export function defaultExpenses(start, end) {
+  return [
+    {
+      name: 'Rent',
+      amount: 1200,
+      paymentsPerYear: 12,
+      growth: 0,
+      category: 'Fixed',
+      priority: 1,
+      startYear: start,
+      endYear: end,
+    },
+    {
+      name: 'Groceries',
+      amount: 300,
+      paymentsPerYear: 12,
+      growth: 0,
+      category: 'Variable',
+      priority: 2,
+      startYear: start,
+      endYear: end,
+    },
+  ]
+}
+
+export function defaultGoals(start) {
+  return [
+    {
+      name: 'Vacation',
+      amount: 5000,
+      targetYear: start + 1,
+      startYear: start,
+      endYear: start + 1,
+    },
+  ]
+}
+
+export function defaultLiabilities(start) {
+  return [
+    {
+      name: 'Car Loan',
+      principal: 10000,
+      interestRate: 5,
+      termYears: 5,
+      paymentsPerYear: 12,
+      extraPayment: 0,
+      startYear: start,
+      endYear: start + 4,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- include default Expenses, Goals and Liabilities
- load defaults on first mount if lists are empty
- add actions to reset or clear lists
- test default loading behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68517b9e25888323a430f041c9169ef9