### PR TITLE
Add internalRateOfReturn helper with tests

### DIFF
--- a/src/__tests__/irr.test.js
+++ b/src/__tests__/irr.test.js
@@ -1,0 +1,16 @@
+/* global test, expect */
+import { internalRateOfReturn } from '../utils/financeUtils'
+
+test('internalRateOfReturn matches known multi-period example', () => {
+  const irr = internalRateOfReturn([-1000, 300, 420, 680])
+  expect(irr).toBeCloseTo(16.34, 2)
+})
+
+test('internalRateOfReturn handles simple two-period case', () => {
+  const irr = internalRateOfReturn([-100, 110])
+  expect(irr).toBeCloseTo(10, 4)
+})
+
+test('internalRateOfReturn returns NaN when cash flows have same sign', () => {
+  expect(internalRateOfReturn([100, 200, 300])).toBeNaN()
+})


### PR DESCRIPTION
## Summary
- implement `internalRateOfReturn` in `financeUtils`
- add unit tests for sample cash flows

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68517f0aa4c08323b9af23b2cded48ea