### PR TITLE
Fix timeline goal allocation

### DIFF
--- a/src/__tests__/timeline.test.js
+++ b/src/__tests__/timeline.test.js
@@ -1,0 +1,25 @@
+import buildTimeline from '../selectors/timeline'
+
+test('goal added only in target year when startYear equals endYear', () => {
+  const timeline = buildTimeline(
+    2024,
+    2026,
+    () => 0,
+    [],
+    [{ amount: 300, startYear: 2025, endYear: 2025 }]
+  )
+  const goals = timeline.map(r => r.goals)
+  expect(goals).toEqual([0, 300, 0])
+})
+
+test('multi-year goal amount is distributed across years', () => {
+  const timeline = buildTimeline(
+    2024,
+    2026,
+    () => 0,
+    [],
+    [{ amount: 300, startYear: 2024, endYear: 2026 }]
+  )
+  const goals = timeline.map(r => r.goals)
+  expect(goals).toEqual([100, 100, 100])
+})

--- a/src/selectors/timeline.js
+++ b/src/selectors/timeline.js
@@ -26,7 +26,13 @@ export default function buildTimeline(
 
     goalsList.forEach(g => {
       if (y >= g.startYear && y <= g.endYear) {
-        goals += Number(g.amount) || 0
+        const amount = Number(g.amount) || 0
+        const years = g.endYear - g.startYear + 1
+        if (years <= 1) {
+          goals += amount
+        } else {
+          goals += amount / years
+        }
       }
     })
 


### PR DESCRIPTION
## Summary
- only add single-year goals once in `buildTimeline`
- spread multi-year goals across their years
- add unit tests for timeline goal allocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685189ef841483239ad9073ea91d4d8f