### PR TITLE
Handle frequency strings in timeline

### DIFF
--- a/src/__tests__/timeline.test.js
+++ b/src/__tests__/timeline.test.js
@@ -23,3 +23,25 @@ test('multi-year goal amount is distributed across years', () => {
   const goals = timeline.map(r => r.goals)
   expect(goals).toEqual([100, 100, 100])
 })
+
+test('string frequency expands to correct payments per year', () => {
+  const timeline = buildTimeline(
+    2024,
+    2024,
+    () => 0,
+    [{ amount: 100, frequency: 'Monthly', startYear: 2024, endYear: 2024 }],
+    []
+  )
+  expect(timeline[0].expenses).toBe(1200)
+})
+
+test('unknown frequency defaults to single payment', () => {
+  const timeline = buildTimeline(
+    2024,
+    2024,
+    () => 0,
+    [{ amount: 100, frequency: 'Weekly', startYear: 2024, endYear: 2024 }],
+    []
+  )
+  expect(timeline[0].expenses).toBe(100)
+})

--- a/src/selectors/timeline.js
+++ b/src/selectors/timeline.js
@@ -1,3 +1,5 @@
+import { frequencyToPayments } from '../utils/financeUtils'
+
 export default function buildTimeline(
   minYear,
   maxYear,
@@ -18,7 +20,10 @@ export default function buildTimeline(
     expensesList.forEach(e => {
       if (y >= e.startYear && y <= e.endYear) {
         const t = y - e.startYear
-        const freq = e.paymentsPerYear || e.frequency || 1
+        const freq =
+          typeof e.paymentsPerYear === 'number'
+            ? e.paymentsPerYear
+            : frequencyToPayments(e.frequency) || 1
         const growth = e.growth || 0
         expenses += (Number(e.amount) || 0) * freq * Math.pow(1 + growth / 100, t)
       }


### PR DESCRIPTION
## Summary
- use `frequencyToPayments` in timeline selector
- add tests for frequency strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68518bcb0be0832395062d059339e765