### PR TITLE
Add loan schedule start date support

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -256,19 +256,20 @@ export default function ExpensesGoalsTab() {
   const liabilityDetails = useMemo(() => {
     return liabilitiesList.map(l => {
       const ratePerPeriod = (Number(l.interestRate) || 0) / 100 / l.paymentsPerYear
+      const start = new Date((l.startYear ?? currentYear), 0, 1).getTime()
       const sched = calculateLoanSchedule({
         principal: Number(l.principal) || 0,
         annualRate: ratePerPeriod * 12,
         termYears: (Number(l.termYears) || 0) * l.paymentsPerYear / 12,
         extraPayment: Number(l.extraPayment) || 0
-      })
+      }, start)
       const pv = presentValue(
         sched.payments.map(p => p.payment),
         (discountRate / 100) / l.paymentsPerYear
       )
       const scheduleMap = {}
-      sched.payments.forEach((p, idx) => {
-        const y = currentYear + Math.floor(idx / l.paymentsPerYear) + 1
+      sched.payments.forEach(p => {
+        const y = new Date(p.date).getFullYear()
         if (!scheduleMap[y]) {
           scheduleMap[y] = { year: y, principalPaid: 0, interestPaid: 0, remaining: p.balance }
         }

--- a/src/modules/loan/loan.test.js
+++ b/src/modules/loan/loan.test.js
@@ -2,12 +2,14 @@
 import { calculateLoanSchedule } from './loanCalculator.js'
 
 test('loan amortization works', () => {
+  const start = new Date(2025, 0, 1).getTime()
   const schedule = calculateLoanSchedule({
     principal: 200000,
     annualRate: 0.045,
     termYears: 30,
     extraPayment: 200
-  })
+  }, start)
   expect(schedule.payments.length).toBeGreaterThan(0)
+  expect(new Date(schedule.payments[0].date).getFullYear()).toBe(2025)
   expect(schedule.totalInterest).toBeGreaterThan(100000)
 })

--- a/src/modules/loan/loanCalculator.js
+++ b/src/modules/loan/loanCalculator.js
@@ -3,15 +3,17 @@ import { presentValue } from './presentValue.js'
 /**
  * Calculate amortization schedule for a loan.
  * @param {import('./loanTypes').LoanInput} input
+ * @param {number|Date} [startDate=Date.now()] - base date for first payment
  * @returns {import('./loanTypes').LoanSchedule}
  */
-export function calculateLoanSchedule(input) {
+export function calculateLoanSchedule(input, startDate = Date.now()) {
   const mRate = input.annualRate / 12
   const n = input.termYears * 12
   const basePay = input.principal * (mRate / (1 - Math.pow(1 + mRate, -n)))
   let balance = input.principal
   let totalInterest = 0
   const payments = []
+  const start = new Date(startDate).getTime()
   for (let i = 1; i <= n && balance > 0; i++) {
     const interest = balance * mRate
     const extra = input.extraPayment || 0
@@ -20,7 +22,7 @@ export function calculateLoanSchedule(input) {
     const payment = interest + principalPaid
     balance -= principalPaid
     totalInterest += interest
-    const date = new Date(Date.now() + 864e5 * 30 * i).toISOString()
+    const date = new Date(start + 864e5 * 30 * i).toISOString()
     payments.push({ date, payment, principalPaid, interestPaid: interest, balance })
   }
   const pvLiability = presentValue(payments.map(p => p.payment), mRate)


### PR DESCRIPTION
## Summary
- allow passing a start date to `calculateLoanSchedule`
- produce payment dates from the provided start
- map amortization years using payment dates and pass loan start year in UI
- update unit tests for new parameter

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851903abdf08323b8c1162327642145