### PR TITLE
Add investments and pension to lifetime chart

### DIFF
--- a/src/__tests__/lifetimeStackedChart.test.js
+++ b/src/__tests__/lifetimeStackedChart.test.js
@@ -9,7 +9,15 @@ beforeAll(() => {
 
 test('renders within ResponsiveContainer and series hide/show when toggled', () => {
   const data = [
-    { year: 2024, income: 100, expenses: 50, goals: 20, debtService: 10 }
+    {
+      year: 2024,
+      income: 100,
+      expenses: 50,
+      goals: 20,
+      debtService: 10,
+      investments: 5,
+      pension: 15
+    }
   ]
   const { container } = render(
     <div style={{ width: 800 }}>
@@ -30,4 +38,18 @@ test('renders within ResponsiveContainer and series hide/show when toggled', () 
   expect(chkDebt).not.toBeChecked()
   fireEvent.click(chkDebt)
   expect(chkDebt).toBeChecked()
+
+  const chkInv = screen.getByLabelText('investments')
+  expect(chkInv).toBeChecked()
+  fireEvent.click(chkInv)
+  expect(chkInv).not.toBeChecked()
+  fireEvent.click(chkInv)
+  expect(chkInv).toBeChecked()
+
+  const chkPen = screen.getByLabelText('pension')
+  expect(chkPen).toBeChecked()
+  fireEvent.click(chkPen)
+  expect(chkPen).not.toBeChecked()
+  fireEvent.click(chkPen)
+  expect(chkPen).toBeChecked()
 })

--- a/src/components/ExpensesGoals/LifetimeStackedChart.jsx
+++ b/src/components/ExpensesGoals/LifetimeStackedChart.jsx
@@ -3,7 +3,14 @@ import { AreaChart, Area, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } f
 import { formatCurrency } from '../../utils/formatters'
 
 export default function LifetimeStackedChart({ data = [], locale, currency }) {
-  const [show, setShow] = useState({ income: true, expenses: true, goals: true, debt: true })
+  const [show, setShow] = useState({
+    income: true,
+    expenses: true,
+    goals: true,
+    debt: true,
+    investments: true,
+    pension: true
+  })
   const format = v => formatCurrency(v, locale, currency)
   const toggle = key => setShow({ ...show, [key]: !show[key] })
   return (
@@ -24,7 +31,36 @@ export default function LifetimeStackedChart({ data = [], locale, currency }) {
           {show.income && <Area type="monotone" dataKey="income" stackId="1" stroke="#4ade80" fill="#bbf7d0" name="Income" />}
           {show.expenses && <Area type="monotone" dataKey="expenses" stackId="1" stroke="#f87171" fill="#fecaca" name="Expenses" />}
           {show.goals && <Area type="monotone" dataKey="goals" stackId="1" stroke="#60a5fa" fill="#bfdbfe" name="Goals" />}
-          {show.debt && <Area type="monotone" dataKey="debtService" stackId="1" stroke="#fbbf24" fill="#fde68a" name="Debt" />}
+          {show.debt && (
+            <Area
+              type="monotone"
+              dataKey="debtService"
+              stackId="1"
+              stroke="#fbbf24"
+              fill="#fde68a"
+              name="Debt"
+            />
+          )}
+          {show.investments && (
+            <Area
+              type="monotone"
+              dataKey="investments"
+              stackId="1"
+              stroke="#a855f7"
+              fill="#e9d5ff"
+              name="Investments"
+            />
+          )}
+          {show.pension && (
+            <Area
+              type="monotone"
+              dataKey="pension"
+              stackId="1"
+              stroke="#14b8a6"
+              fill="#99f6e4"
+              name="Pension"
+            />
+          )}
         </AreaChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- include investments and pension in the show state for `LifetimeStackedChart`
- render new `<Area>` series for investments and pension with unique colors
- allow toggling the new series via checkboxes
- extend tests for new checkbox behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551db831808323ab86b6018dd70f64