### PR TITLE
Add default investments and pension samples

### DIFF
--- a/src/__tests__/expensesGoals.defaults.test.js
+++ b/src/__tests__/expensesGoals.defaults.test.js
@@ -36,13 +36,23 @@ test('defaults populate when lists empty', async () => {
   await screen.findByText(/PV of Expenses/)
   await waitFor(() => localStorage.getItem('expensesList') !== '[]', { timeout: 2000 })
   await waitFor(() => localStorage.getItem('goalsList') !== '[]', { timeout: 2000 })
+  await waitFor(() => localStorage.getItem('investmentContributions') !== '[]', { timeout: 2000 })
+  await waitFor(() => localStorage.getItem('pensionStreams') !== '[]', { timeout: 2000 })
 })
 
 test('defaults not loaded when stored data present', async () => {
   localStorage.setItem('expensesList', JSON.stringify([
     { name: 'Gym', amount: 50, paymentsPerYear: 12, startYear: 2024, priority: 1 }
   ]))
+  localStorage.setItem('investmentContributions', JSON.stringify([
+    { name: 'Seed', amount: 100, frequency: 12, startYear: 2024 }
+  ]))
+  localStorage.setItem('pensionStreams', JSON.stringify([
+    { name: 'Legacy Pension', amount: 5000, frequency: 12, startYear: 2060 }
+  ]))
   mount()
   await screen.findByText(/PV of Expenses/)
   await waitFor(() => localStorage.getItem('expensesList')?.includes('Gym'), { timeout: 2000 })
+  await waitFor(() => localStorage.getItem('investmentContributions')?.includes('Seed'), { timeout: 2000 })
+  await waitFor(() => localStorage.getItem('pensionStreams')?.includes('Legacy'), { timeout: 2000 })
 })

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -39,8 +39,8 @@ export default function ExpensesGoalsTab() {
     expensesList, setExpensesList,
     goalsList,    setGoalsList,
     liabilitiesList, setLiabilitiesList,
-    investmentContributions,
-    pensionStreams,
+    investmentContributions, setInvestmentContributions,
+    pensionStreams, setPensionStreams,
     setExpensesPV,
     setGoalsPV,
     profile,
@@ -63,13 +63,49 @@ export default function ExpensesGoalsTab() {
   // Populate defaults on first mount when no data is present
   useEffect(() => {
     if (expensesList.length === 0) {
-      setExpensesList(defaultExpenses(defaultStart, defaultEnd))
+      const list = defaultExpenses(defaultStart, defaultEnd)
+      setExpensesList(list)
+      storage.set('expensesList', JSON.stringify(list))
     }
     if (goalsList.length === 0) {
-      setGoalsList(defaultGoals(defaultStart))
+      const list = defaultGoals(defaultStart)
+      setGoalsList(list)
+      storage.set('goalsList', JSON.stringify(list))
     }
     if (liabilitiesList.length === 0) {
-      setLiabilitiesList(defaultLiabilities(defaultStart))
+      const list = defaultLiabilities(defaultStart)
+      setLiabilitiesList(list)
+      storage.set('liabilitiesList', JSON.stringify(list))
+    }
+    if (investmentContributions.length === 0) {
+      const list = [
+        {
+          id: crypto.randomUUID(),
+          name: 'Mutual Fund',
+          amount: 500,
+          frequency: 12,
+          growth: 0,
+          startYear: defaultStart,
+          endYear: defaultStart + 5,
+        },
+      ]
+      setInvestmentContributions(list)
+      storage.set('investmentContributions', JSON.stringify(list))
+    }
+    if (pensionStreams.length === 0) {
+      const list = [
+        {
+          id: crypto.randomUUID(),
+          name: 'Pension',
+          amount: 15000,
+          frequency: 12,
+          growth: 0,
+          startYear: defaultStart + 30,
+          endYear: defaultStart + 50,
+        },
+      ]
+      setPensionStreams(list)
+      storage.set('pensionStreams', JSON.stringify(list))
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- add realistic investment & pension defaults on first mount
- persist new defaults to storage
- test initialization logic when local storage is empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551f88d8d48323905033d34e43996f