### PR TITLE
Add persona support with context

### DIFF
--- a/personal-finance-app-guide.md
+++ b/personal-finance-app-guide.md
@@ -1,0 +1,23 @@
+# Persona Switching Guide
+
+This app now supports multiple sample personas bundled under `src/data/personas.json`.
+A dropdown in the sidebar lets you pick which persona to work with.
+
+1. **Start the App**
+   ```bash
+   npm install
+   npm run dev
+   ```
+2. **Select a Persona**
+   Use the *Persona* dropdown above the navigation tabs. Choosing a different
+   persona clears local storage and loads the selected profile, income sources
+   and other data.
+3. **Work with the Data**
+   All tabs reflect the chosen persona. Changes you make are persisted to local
+   storage while that persona is active.
+4. **Exporting**
+   When exporting JSON or CSV files, the persona’s name is included in the
+   filename (e.g. `income-data-Hadi_Mwangi.json`).
+
+Switching personas at any time will repopulate local storage with the new
+persona’s dataset.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,9 @@ import React, { Suspense, useState } from 'react'
 import Spinner from './Spinner.jsx'
 import Header from './components/layout/Header.jsx'
 import Sidebar from './components/layout/Sidebar.jsx'
+import { FinanceProvider } from './FinanceContext.jsx'
+import { PersonaProvider, usePersona } from './PersonaContext.jsx'
+import personas from './data/personas.json'
 
 const IncomeTab = React.lazy(() => import('./components/Income/IncomeTab.jsx'))
 const ExpensesGoalsTab = React.lazy(() => import('./components/ExpensesGoals/ExpensesGoalsTab.jsx'))
@@ -26,7 +29,7 @@ const components = {
   Insurance: InsuranceTab,
 }
 
-export default function App() {
+function AppInner() {
   const [activeTab, setActiveTab] = useState('Profile')
   const Active = components[activeTab]
 
@@ -45,5 +48,22 @@ export default function App() {
         Projections are for illustrative purposes only.
       </footer>
     </div>
+  )
+}
+
+function AppWithFinance() {
+  const { currentPersonaId } = usePersona()
+  return (
+    <FinanceProvider key={currentPersonaId}>
+      <AppInner />
+    </FinanceProvider>
+  )
+}
+
+export default function App() {
+  return (
+    <PersonaProvider personas={personas}>
+      <AppWithFinance />
+    </PersonaProvider>
   )
 }

--- a/src/PersonaContext.jsx
+++ b/src/PersonaContext.jsx
@@ -1,0 +1,58 @@
+import React, { createContext, useContext, useState } from 'react'
+import personasData from './data/personas.json'
+import storage from './utils/storage'
+
+const PersonaContext = createContext()
+
+export function PersonaProvider({ children }) {
+  const [currentPersonaId, _setCurrentPersonaId] = useState(() => {
+    return storage.get('currentPersonaId') || personasData[0].id
+  })
+  const [currentData, setCurrentData] = useState(() => {
+    const id = storage.get('currentPersonaId') || personasData[0].id
+    return personasData.find(p => p.id === id) || personasData[0]
+  })
+
+  const setCurrentPersonaId = (id) => {
+    const persona = personasData.find(p => p.id === id) || personasData[0]
+    _setCurrentPersonaId(id)
+    setCurrentData(persona)
+    storage.set('currentPersonaId', id)
+
+    Object.keys(localStorage).forEach(k => {
+      if (k !== 'currentPersonaId') localStorage.removeItem(k)
+    })
+
+    if (persona.profile) storage.set('profile', JSON.stringify(persona.profile))
+    if (persona.incomeSources) storage.set('incomeSources', JSON.stringify(persona.incomeSources))
+    if (persona.expensesList) storage.set('expensesList', JSON.stringify(persona.expensesList))
+    if (persona.goalsList) storage.set('goalsList', JSON.stringify(persona.goalsList))
+    if (persona.assetsList) storage.set('assetsList', JSON.stringify(persona.assetsList))
+    if (persona.liabilitiesList) storage.set('liabilitiesList', JSON.stringify(persona.liabilitiesList))
+    if (persona.settings) storage.set('settings', JSON.stringify(persona.settings))
+    if ('includeMediumPV' in persona) storage.set('includeMediumPV', JSON.stringify(persona.includeMediumPV))
+    if ('includeLowPV' in persona) storage.set('includeLowPV', JSON.stringify(persona.includeLowPV))
+    if ('includeGoalsPV' in persona) storage.set('includeGoalsPV', JSON.stringify(persona.includeGoalsPV))
+    if ('includeLiabilitiesNPV' in persona) storage.set('includeLiabilitiesNPV', JSON.stringify(persona.includeLiabilitiesNPV))
+  }
+
+  return (
+    <PersonaContext.Provider value={{ currentPersonaId, setCurrentPersonaId, currentData, personas: personasData }}>
+      {children}
+    </PersonaContext.Provider>
+  )
+}
+
+export const usePersona = () => {
+  const ctx = useContext(PersonaContext)
+  if (!ctx) {
+    const def = personasData[0]
+    return {
+      currentPersonaId: def.id,
+      setCurrentPersonaId: () => {},
+      currentData: def,
+      personas: personasData
+    }
+  }
+  return ctx
+}

--- a/src/__tests__/personaSwitch.test.js
+++ b/src/__tests__/personaSwitch.test.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import App from '../App'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+test('switching personas updates profile and income tabs', async () => {
+  render(<App />)
+
+  // initial persona is hadi
+  await screen.findByText(/Hadi Mwangi/i)
+
+  // switch to Amina via dropdown
+  fireEvent.change(screen.getByLabelText(/Persona/i), { target: { value: 'amina' } })
+
+  // profile tab shows new name
+  await screen.findByText(/Amina Okoth/i)
+  await waitFor(() => expect(localStorage.getItem('currentPersonaId')).toBe('amina'))
+
+  // open Income tab so FinanceProvider loads income data
+  fireEvent.click(screen.getByRole('tab', { name: /Income/i }))
+  await screen.findByText(/Income Sources/i)
+  await waitFor(() => {
+    const stored = JSON.parse(localStorage.getItem('incomeSources'))
+    expect(stored[0].name).toBe('Consulting')
+  })
+})

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -438,7 +438,8 @@ export default function ExpensesGoalsTab() {
     const url  = URL.createObjectURL(blob)
     const a    = document.createElement('a')
     a.href     = url
-    a.download = 'financial-plan.json'
+    const name = profile.name.replace(/\s+/g, '_')
+    a.download = `financial-plan-${name}.json`
     a.click()
   }
 
@@ -448,7 +449,8 @@ export default function ExpensesGoalsTab() {
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
-    a.download = 'financial-plan.csv'
+    const name = profile.name.replace(/\s+/g, '_')
+    a.download = `financial-plan-${name}.csv`
     a.click()
   }
 

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -230,7 +230,8 @@ export default function IncomeTab() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'income-data.json';
+    const name = profile.name.replace(/\s+/g, '_');
+    a.download = `income-data-${name}.json`;
     a.click();
   };
 
@@ -258,7 +259,8 @@ export default function IncomeTab() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = 'income-data.csv';
+    const name = profile.name.replace(/\s+/g, '_');
+    a.download = `income-data-${name}.csv`;
     a.click();
   };
 

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { usePersona } from '../../PersonaContext'
 
 const sections = [
   'Profile',
@@ -13,9 +14,21 @@ const sections = [
 ]
 
 export default function Sidebar({ activeTab, onSelect }) {
+  const { currentPersonaId, setCurrentPersonaId, personas } = usePersona()
   return (
     <aside className="w-72 bg-white border-r overflow-y-auto">
       <div className="p-6">
+        <label className="block mb-4 text-sm" htmlFor="persona-select">Persona</label>
+        <select
+          id="persona-select"
+          className="mb-4 w-full border rounded px-2 py-1"
+          value={currentPersonaId}
+          onChange={e => setCurrentPersonaId(e.target.value)}
+        >
+          {personas.map(p => (
+            <option key={p.id} value={p.id}>{p.profile.name}</option>
+          ))}
+        </select>
         <h2 className="text-lg font-medium text-amber-600 mb-4">Getting Started</h2>
         <nav className="space-y-2" role="tablist">
           {sections.map(tab => (

--- a/src/data/personas.json
+++ b/src/data/personas.json
@@ -1,0 +1,247 @@
+[
+  {
+    "id": "hadi",
+    "profile": {
+      "name": "Hadi Mwangi",
+      "email": "hadi.mwangi@example.com",
+      "phone": "+254712345678",
+      "age": 35,
+      "lifeExpectancy": 85,
+      "maritalStatus": "Married",
+      "numDependents": 2,
+      "residentialAddress": "Nairobi, Kenya",
+      "nationality": "Kenyan",
+      "idNumber": "34567890",
+      "taxResidence": "Kenya",
+      "employmentStatus": "Full-Time",
+      "annualIncome": 3000000,
+      "liquidNetWorth": 2000000,
+      "sourceOfFunds": "Employment, rental income, long-term ETF investments",
+      "investmentKnowledge": "Moderate",
+      "lossResponse": "Wait",
+      "investmentHorizon": ">7 years",
+      "investmentGoal": "Growth"
+    },
+    "incomeSources": [
+      {
+        "name": "Salary",
+        "amount": 250000,
+        "frequency": 12,
+        "growth": 4,
+        "taxRate": 30
+      },
+      {
+        "name": "Rental Income",
+        "amount": 30000,
+        "frequency": 12,
+        "growth": 3,
+        "taxRate": 10
+      }
+    ],
+    "expensesList": [
+      {
+        "name": "Rent",
+        "amount": 80000,
+        "frequency": "Monthly",
+        "growth": 5,
+        "category": "Fixed",
+        "priority": 1
+      },
+      {
+        "name": "Transport",
+        "amount": 10000,
+        "frequency": "Monthly",
+        "growth": 2,
+        "category": "Variable",
+        "priority": 2
+      }
+    ],
+    "goalsList": [
+      {
+        "name": "Family Vacation",
+        "amount": 300000,
+        "targetYear": 2026,
+        "priority": 2
+      }
+    ],
+    "assetsList": [
+      {
+        "id": "real-estate",
+        "name": "Land in Nanyuki",
+        "value": 2500000,
+        "return": 6,
+        "volatility": 12
+      }
+    ],
+    "liabilitiesList": [
+      {
+        "id": "car-loan",
+        "name": "Car Loan",
+        "principal": 500000,
+        "interestRate": 12,
+        "monthlyPayment": 15000,
+        "termMonths": 48,
+        "startDate": "2023-07-01"
+      }
+    ],
+    "settings": {
+      "inflationRate": 5,
+      "expectedReturn": 8,
+      "currency": "KES",
+      "locale": "en-KE",
+      "discretionaryCutThreshold": 15,
+      "survivalThresholdMonths": 6,
+      "bufferPct": 10,
+      "apiEndpoint": "https://api.local/submit"
+    },
+    "includeMediumPV": true,
+    "includeLowPV": true,
+    "includeGoalsPV": true,
+    "includeLiabilitiesNPV": true
+  },
+  {
+    "id": "amina",
+    "profile": {
+      "name": "Amina Okoth",
+      "email": "amina.okoth@example.com",
+      "phone": "+254700111222",
+      "age": 28,
+      "lifeExpectancy": 85,
+      "maritalStatus": "Single",
+      "numDependents": 0,
+      "residentialAddress": "Mombasa, Kenya",
+      "nationality": "Kenyan",
+      "idNumber": "56789012",
+      "taxResidence": "Kenya",
+      "employmentStatus": "Self-Employed",
+      "annualIncome": 1800000,
+      "liquidNetWorth": 800000,
+      "sourceOfFunds": "Consulting income",
+      "investmentKnowledge": "Low",
+      "lossResponse": "Sell",
+      "investmentHorizon": "3-7 years",
+      "investmentGoal": "Balanced"
+    },
+    "incomeSources": [
+      {
+        "name": "Consulting",
+        "amount": 150000,
+        "frequency": 12,
+        "growth": 5,
+        "taxRate": 25
+      }
+    ],
+    "expensesList": [
+      {
+        "name": "Rent",
+        "amount": 40000,
+        "frequency": "Monthly",
+        "growth": 3,
+        "category": "Fixed",
+        "priority": 1
+      }
+    ],
+    "goalsList": [],
+    "assetsList": [
+      {
+        "id": "savings",
+        "name": "Savings Account",
+        "value": 300000,
+        "return": 2,
+        "volatility": 0
+      }
+    ],
+    "liabilitiesList": [],
+    "settings": {
+      "inflationRate": 4,
+      "expectedReturn": 6,
+      "currency": "KES",
+      "locale": "en-KE"
+    },
+    "includeMediumPV": true,
+    "includeLowPV": true,
+    "includeGoalsPV": false,
+    "includeLiabilitiesNPV": false
+  },
+  {
+    "id": "yusuf",
+    "profile": {
+      "name": "Yusuf Ahmed",
+      "email": "yusuf.ahmed@example.com",
+      "phone": "+254733444555",
+      "age": 42,
+      "lifeExpectancy": 85,
+      "maritalStatus": "Married",
+      "numDependents": 3,
+      "residentialAddress": "Nakuru, Kenya",
+      "nationality": "Kenyan",
+      "idNumber": "78901234",
+      "taxResidence": "Kenya",
+      "employmentStatus": "Full-Time",
+      "annualIncome": 2200000,
+      "liquidNetWorth": 1500000,
+      "sourceOfFunds": "Employment",
+      "investmentKnowledge": "High",
+      "lossResponse": "Hold",
+      "investmentHorizon": ">7 years",
+      "investmentGoal": "Growth"
+    },
+    "incomeSources": [
+      {
+        "name": "Salary",
+        "amount": 180000,
+        "frequency": 12,
+        "growth": 3,
+        "taxRate": 30
+      }
+    ],
+    "expensesList": [
+      {
+        "name": "Mortgage",
+        "amount": 60000,
+        "frequency": "Monthly",
+        "growth": 2,
+        "category": "Fixed",
+        "priority": 1
+      }
+    ],
+    "goalsList": [
+      {
+        "name": "Children's College",
+        "amount": 800000,
+        "targetYear": 2032,
+        "priority": 1
+      }
+    ],
+    "assetsList": [
+      {
+        "id": "house",
+        "name": "Family Home",
+        "value": 4000000,
+        "return": 5,
+        "volatility": 8
+      }
+    ],
+    "liabilitiesList": [
+      {
+        "id": "mortgage",
+        "name": "Mortgage",
+        "principal": 2500000,
+        "interestRate": 10,
+        "monthlyPayment": 50000,
+        "termMonths": 240,
+        "startDate": "2020-01-01"
+      }
+    ],
+    "settings": {
+      "inflationRate": 5,
+      "expectedReturn": 7,
+      "currency": "KES",
+      "locale": "en-KE"
+    },
+    "includeMediumPV": true,
+    "includeLowPV": true,
+    "includeGoalsPV": true,
+    "includeLiabilitiesNPV": true
+  }
+]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,69 @@
+export interface Profile {
+  name: string
+  email: string
+  phone: string
+  age: number
+  lifeExpectancy: number
+  [key: string]: any
+}
+
+export interface IncomeItem {
+  name: string
+  amount: number
+  frequency: number | string
+  growth?: number
+  taxRate?: number
+  startYear?: number
+  endYear?: number | null
+  type?: string
+  linkedAssetId?: string
+  active?: boolean
+}
+
+export interface ExpenseItem {
+  name: string
+  amount: number
+  frequency: number | string
+  growth?: number
+  category?: string
+  priority?: number
+  paymentsPerYear?: number
+  startYear?: number
+  endYear?: number | null
+}
+
+export interface Asset {
+  id: string
+  name: string
+  value: number
+  type?: string
+  expectedReturn?: number
+  volatility?: number
+  horizonYears?: number
+  return?: number
+}
+
+export interface Liability {
+  id: string
+  name: string
+  principal: number
+  interestRate: number
+  monthlyPayment: number
+  termMonths: number
+  startDate?: string
+}
+
+export interface Persona {
+  id: string
+  profile: Profile
+  incomeSources: IncomeItem[]
+  expensesList: ExpenseItem[]
+  goalsList: ExpenseItem[]
+  assetsList: Asset[]
+  liabilitiesList: Liability[]
+  settings: any
+  includeMediumPV?: boolean
+  includeLowPV?: boolean
+  includeGoalsPV?: boolean
+  includeLiabilitiesNPV?: boolean
+}


### PR DESCRIPTION
## Summary
- add persona datasets and types
- support persona switching via new context and sidebar dropdown
- export filenames include persona name
- provide guide documentation
- test persona switching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68552f39e04c832396e7d549a9327d45