### PR TITLE
Add expenses stacked bar chart

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -13,6 +13,7 @@ import { expenseItemSchema, goalItemSchema } from '../../schemas/expenseGoalSche
 import { frequencyToPayments } from '../../utils/financeUtils'
 import { ResponsiveContainer } from 'recharts'
 import LifetimeStackedChart from './LifetimeStackedChart'
+import ExpensesStackedBarChart from '../ExpensesStackedBarChart.jsx'
 import buildTimeline from '../../selectors/timeline'
 import { annualAmountForYear } from '../../utils/streamHelpers'
 import { Card, CardHeader, CardBody } from '../common/Card.jsx'
@@ -564,9 +565,11 @@ export default function ExpensesGoalsTab() {
                 onDelete={removeExpense}
               />
             ))}
-          </CardBody>
+      </CardBody>
         )}
       </Card>
+
+      <ExpensesStackedBarChart />
 
       <Card className="mb-6">
         <CardHeader>

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
+} from 'recharts'
+import { useFinance } from '../FinanceContext'
+
+export default function ExpensesStackedBarChart() {
+  const { expensesList } = useFinance()
+
+  // Aggregate expenses by year and category
+  const dataByYear = {}
+  expensesList.forEach(exp => {
+    const { category, frequency, amount, startYear, endYear = startYear } = exp
+    for (let year = startYear; year <= (endYear ?? startYear); year++) {
+      if (!dataByYear[year]) dataByYear[year] = { year: String(year) }
+      // Convert monthly to annual amount
+      const value = frequency === 'Monthly' ? amount * 12 : amount
+      dataByYear[year][category] = (dataByYear[year][category] || 0) + value
+    }
+  })
+
+  const chartData = Object.values(dataByYear).sort((a, b) => a.year - b.year)
+
+  return (
+    <div className="w-full h-80 bg-white p-4 rounded-xl shadow-md">
+      <h3 className="text-lg font-semibold mb-2">Expenses Over Time</h3>
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="year" />
+          <YAxis />
+          <Tooltip />
+          <Legend formatter={(value) => value} />
+          <Bar dataKey="Fixed" stackId="a" fill="#1f77b4" />
+          <Bar dataKey="Discretionary" stackId="a" fill="#ff7f0e" />
+          <Bar dataKey="Goal" stackId="a" fill="#2ca02c" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- visualize expenses categories over time with a new stacked bar chart
- display new chart in Expenses & Goals tab

## Testing
- `npm install --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6855431c7dd48323a4a13125c936db3e