### PR TITLE
Fix expenses stacked chart end year

### DIFF
--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -1,19 +1,34 @@
 import React from 'react'
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
 } from 'recharts'
 import { useFinance } from '../FinanceContext'
 
 export default function ExpensesStackedBarChart() {
-  const { expensesList } = useFinance()
+  const { expensesList, startYear, years } = useFinance()
+
+  const horizonEnd = startYear + years - 1
 
   // Aggregate expenses by year and category
   const dataByYear = {}
   expensesList.forEach(exp => {
-    const { category, frequency, amount, startYear, endYear = startYear } = exp
-    for (let year = startYear; year <= (endYear ?? startYear); year++) {
+    const {
+      category,
+      frequency,
+      amount,
+      startYear: sYear,
+      endYear,
+    } = exp
+    const finalYear = endYear ?? horizonEnd
+    for (let year = sYear; year <= finalYear; year++) {
       if (!dataByYear[year]) dataByYear[year] = { year: String(year) }
-      // Convert monthly to annual amount
       const value = frequency === 'Monthly' ? amount * 12 : amount
       dataByYear[year][category] = (dataByYear[year][category] || 0) + value
     }


### PR DESCRIPTION
## Summary
- account for projection horizon when defaulting an expense end year in `ExpensesStackedBarChart`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685556f830c48323b831697e2328698a