### PR TITLE
Integrate PV toggles with expenses tab

### DIFF
--- a/src/__tests__/expensesGoals.pvUpdate.test.js
+++ b/src/__tests__/expensesGoals.pvUpdate.test.js
@@ -14,6 +14,8 @@ afterEach(() => {
 
 function setup() {
   localStorage.setItem('profile', JSON.stringify({ nationality: 'Kenyan', age: 30, lifeExpectancy: 85 }))
+  localStorage.setItem('includeGoalsPV', 'true')
+  localStorage.setItem('includeLiabilitiesNPV', 'true')
   return render(
     <FinanceProvider>
       <ExpensesGoalsTab />

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -5,11 +5,21 @@ import {
 import { useFinance } from '../FinanceContext'
 
 export default function ExpensesStackedBarChart() {
-  const { expensesList } = useFinance()
+  const {
+    expensesList,
+    includeMediumPV,
+    includeLowPV,
+  } = useFinance()
 
   // Aggregate expenses by year and category
+  const filtered = expensesList.filter(e => {
+    if (e.priority === 2 && !includeMediumPV) return false
+    if (e.priority > 2 && !includeLowPV) return false
+    return true
+  })
+
   const dataByYear = {}
-  expensesList.forEach(exp => {
+  filtered.forEach(exp => {
     const { category, frequency, amount, startYear, endYear = startYear } = exp
     for (let year = startYear; year <= (endYear ?? startYear); year++) {
       if (!dataByYear[year]) dataByYear[year] = { year: String(year) }


### PR DESCRIPTION
## Summary
- wire include*PV settings into ExpensesGoals tab calculations
- filter data by priority in ExpensesStackedBarChart
- update PV update tests to enable goal and liability toggles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855638497808323aa81e0f420d30947