### PR TITLE
Update goal flows

### DIFF
--- a/src/__tests__/timeline.test.js
+++ b/src/__tests__/timeline.test.js
@@ -6,22 +6,22 @@ test('goal added only in target year when startYear equals endYear', () => {
     2026,
     () => 0,
     [],
-    [{ amount: 300, startYear: 2025, endYear: 2025 }]
+    [{ amount: 300, startYear: 2025, endYear: 2025, targetYear: 2025 }]
   )
   const goals = timeline.map(r => r.goals)
   expect(goals).toEqual([0, 300, 0])
 })
 
-test('multi-year goal amount is distributed across years', () => {
+test('multi-year goal occurs only in target year', () => {
   const timeline = buildTimeline(
     2024,
     2026,
     () => 0,
     [],
-    [{ amount: 300, startYear: 2024, endYear: 2026 }]
+    [{ amount: 300, startYear: 2024, endYear: 2026, targetYear: 2026 }]
   )
   const goals = timeline.map(r => r.goals)
-  expect(goals).toEqual([100, 100, 100])
+  expect(goals).toEqual([0, 0, 300])
 })
 
 test('string frequency expands to correct payments per year', () => {

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -7,8 +7,10 @@ import { useFinance } from '../FinanceContext'
 export default function ExpensesStackedBarChart() {
   const {
     expensesList,
+    goalsList,
     includeMediumPV,
     includeLowPV,
+    includeGoalsPV,
   } = useFinance()
 
   // Aggregate expenses by year and category
@@ -28,6 +30,16 @@ export default function ExpensesStackedBarChart() {
       dataByYear[year][category] = (dataByYear[year][category] || 0) + value
     }
   })
+
+  if (includeGoalsPV) {
+    goalsList.forEach(g => {
+      const yr = g.targetYear ?? g.endYear ?? g.startYear
+      const year = Number(yr)
+      if (year == null) return
+      if (!dataByYear[year]) dataByYear[year] = { year: String(year) }
+      dataByYear[year].Goal = (dataByYear[year].Goal || 0) + (Number(g.amount) || 0)
+    })
+  }
 
   const chartData = Object.values(dataByYear).sort((a, b) => a.year - b.year)
 

--- a/src/selectors/timeline.js
+++ b/src/selectors/timeline.js
@@ -30,14 +30,9 @@ export default function buildTimeline(
     })
 
     goalsList.forEach(g => {
-      if (y >= g.startYear && y <= g.endYear) {
-        const amount = Number(g.amount) || 0
-        const years = g.endYear - g.startYear + 1
-        if (years <= 1) {
-          goals += amount
-        } else {
-          goals += amount / years
-        }
+      const year = g.targetYear ?? g.endYear ?? g.startYear
+      if (year === y) {
+        goals += Number(g.amount) || 0
       }
     })
 


### PR DESCRIPTION
## Summary
- generate one-off goal bars from `goalsList`
- use target year when creating timeline goal flows
- adjust timeline tests for new goal logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855662323408323bc9b21aef99aa36b