### PR TITLE
Add tests for projection toggles and loan payment

### DIFF
--- a/src/__tests__/chartSpan.test.js
+++ b/src/__tests__/chartSpan.test.js
@@ -1,0 +1,11 @@
+import buildTimeline from '../selectors/timeline'
+
+test('timeline spans retirement horizon when expenses extend forward', () => {
+  const current = 2024
+  const retirementYear = 2028
+  const expenses = [
+    { amount: 100, paymentsPerYear: 12, startYear: current, endYear: retirementYear }
+  ]
+  const timeline = buildTimeline(current, retirementYear, () => 0, expenses, [])
+  expect(timeline).toHaveLength(retirementYear - current + 1)
+})

--- a/src/__tests__/includeProjection.test.js
+++ b/src/__tests__/includeProjection.test.js
@@ -1,0 +1,18 @@
+import { calculatePV, generateIncomeTimeline } from '../components/Income/helpers'
+
+test('inactive income excluded from PV totals and timeline', () => {
+  const current = new Date().getFullYear()
+  const assumptions = { retirementAge: current + 5, deathAge: current + 5 }
+  const active = { amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: current, active: true }
+  const inactive = { ...active, active: false }
+  const pvActive = calculatePV(active, 0, 5, assumptions)
+  const pvInactive = inactive.active ? calculatePV(inactive, 0, 5, assumptions) : { gross: 0, net: 0 }
+  expect(pvInactive.gross).toBe(0)
+  const total = [active, inactive].map(s => s.active ? calculatePV(s, 0, 5, assumptions) : {gross:0, net:0})
+    .reduce((sum, p) => sum + p.gross, 0)
+  expect(total).toBeCloseTo(pvActive.gross)
+
+  const timeline = generateIncomeTimeline([active, inactive], assumptions, [], 5)
+  const expected = generateIncomeTimeline([active], assumptions, [], 5)
+  expect(timeline).toEqual(expected)
+})

--- a/src/__tests__/monthlyPayment.test.js
+++ b/src/__tests__/monthlyPayment.test.js
@@ -1,0 +1,14 @@
+import { defaultLiabilities } from '../components/ExpensesGoals/defaults'
+import { calculateAmortizedPayment } from '../utils/financeUtils'
+
+test('default liabilities compute monthly payment', () => {
+  const start = 2024
+  const [loan] = defaultLiabilities(start)
+  const expected = calculateAmortizedPayment(
+    loan.principal,
+    loan.interestRate,
+    loan.termYears,
+    loan.paymentsPerYear
+  )
+  expect(loan.computedPayment).toBeCloseTo(expected)
+})


### PR DESCRIPTION
## Summary
- test that inactive income streams are excluded from PV totals and timeline
- verify loan monthly payment computation for default liabilities
- ensure timeline spans retirement horizon when expenses extend

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685569327a4c83238b5734138acd24ee