### PR TITLE
Add include flags for expenses/liabilities

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -175,6 +175,7 @@ export function FinanceProvider({ children }) {
           id: exp.id || crypto.randomUUID(),
           startYear: exp.startYear ?? now,
           endYear: exp.endYear ?? null,
+          include: exp.include !== false,
           ...exp,
           paymentsPerYear,
           priority: exp.priority ?? 2,
@@ -321,7 +322,11 @@ export function FinanceProvider({ children }) {
     if (s) {
       try {
         const parsed = JSON.parse(s)
-        return parsed.map(l => ({ id: l.id || crypto.randomUUID(), ...l }))
+        return parsed.map(l => ({
+          id: l.id || crypto.randomUUID(),
+          include: l.include !== false,
+          ...l,
+        }))
       } catch {
         // ignore malformed stored data
       }
@@ -467,6 +472,7 @@ export function FinanceProvider({ children }) {
             startYear: e.startYear ?? now,
             endYear: e.endYear ?? null,
             priority: e.priority ?? 2,
+            include: e.include !== false,
             ...e,
           }))
           setExpensesList(list)
@@ -502,6 +508,7 @@ export function FinanceProvider({ children }) {
             remainingMonths: l.termMonths,
             paymentsPerYear: 12,
             payment: l.monthlyPayment,
+            include: l.include !== false,
           }))
           setLiabilitiesList(liabs)
         }

--- a/src/components/ExpenseRow.jsx
+++ b/src/components/ExpenseRow.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { FREQUENCY_LABELS } from '../constants.js'
 
-export default function ExpenseRow({ id, name, amount, frequency, category, startYear, endYear, onChange, onDelete }) {
+export default function ExpenseRow({ id, name, amount, frequency, category, startYear, endYear, include = true, onChange, onDelete }) {
   const makeId = field => `${id}-${field}`
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-6 gap-2 items-center mb-1 bg-white p-2 rounded-md shadow relative">
+    <div className="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mb-1 bg-white p-2 rounded-md shadow relative">
       <div>
         <label htmlFor={makeId('name')} className="block text-sm font-medium">Name</label>
         <input
@@ -89,6 +89,19 @@ export default function ExpenseRow({ id, name, amount, frequency, category, star
           value={endYear ?? ''}
           onChange={e => onChange(id, 'endYear', e.target.value)}
         />
+      </div>
+
+      <div className="flex items-center mt-6 sm:mt-0">
+        <input
+          id={makeId('include')}
+          aria-label="Include in PV"
+          title="Include in PV"
+          type="checkbox"
+          className="mr-1"
+          checked={include}
+          onChange={e => onChange(id, 'include', e.target.checked)}
+        />
+        <label htmlFor={makeId('include')} className="text-sm">Include</label>
       </div>
 
       <button

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -76,6 +76,7 @@ export default function ExpensesGoalsTab() {
   const filteredExpenses = useMemo(
     () =>
       expensesList.filter(e => {
+        if (e.include === false) return false
         if (e.priority === 2 && !includeMediumPV) return false
         if (e.priority > 2 && !includeLowPV) return false
         return true
@@ -185,6 +186,7 @@ export default function ExpensesGoalsTab() {
         growth: 0,
         category: 'Fixed',
         priority: 2,
+        include: true,
         startYear: defaultStart,
         endYear: defaultEnd,
       },
@@ -282,6 +284,7 @@ export default function ExpensesGoalsTab() {
       termYears: 1,
       paymentsPerYear: 12,
       extraPayment: 0,
+      include: true,
       startYear: defaultStart,
       endYear: defaultEnd,
     }
@@ -355,7 +358,7 @@ export default function ExpensesGoalsTab() {
 
   // --- 4) Loan details & amortization ---
   const liabilityDetails = useMemo(() => {
-    return liabilitiesList.map(l => {
+    return liabilitiesList.filter(l => l.include !== false).map(l => {
       const ratePerPeriod = (Number(l.interestRate) || 0) / 100 / l.paymentsPerYear
       const start = new Date((l.startYear ?? currentYear), 0, 1).getTime()
       const sched = calculateLoanSchedule({
@@ -593,13 +596,14 @@ export default function ExpensesGoalsTab() {
         </CardHeader>
         {showExpenses && (
           <CardBody>
-            <div className="grid grid-cols-1 sm:grid-cols-6 gap-2 font-semibold text-gray-700 mb-1">
+            <div className="grid grid-cols-1 sm:grid-cols-7 gap-2 font-semibold text-gray-700 mb-1">
               <div>Name</div>
               <div className="text-right">Amt ({settings.currency})</div>
               <div>Pay/Yr</div>
               <div>Category</div>
               <div>Start</div>
               <div>End</div>
+              <div>Include</div>
             </div>
             {expensesList.length === 0 && (
               <p className="italic text-slate-500 col-span-full mb-2">No expenses added</p>
@@ -614,6 +618,7 @@ export default function ExpensesGoalsTab() {
                 category={e.category}
                 startYear={e.startYear ?? defaultStart}
                 endYear={e.endYear ?? defaultEnd}
+                include={e.include !== false}
                 onChange={handleExpenseChange}
                 onDelete={removeExpense}
               />
@@ -757,20 +762,21 @@ export default function ExpensesGoalsTab() {
         </CardHeader>
         {showLiabilities && (
           <CardBody>
-            <div className="grid grid-cols-1 sm:grid-cols-7 gap-2 font-semibold text-gray-700 mb-1">
+            <div className="grid grid-cols-1 sm:grid-cols-8 gap-2 font-semibold text-gray-700 mb-1">
               <div>Name</div>
               <div className="text-right">Principal</div>
               <div className="text-right">Rate %</div>
               <div className="text-right">Term</div>
               <div>Pay/Yr</div>
               <div className="text-right">Extra</div>
+              <div>Include</div>
               <div></div>
             </div>
             {liabilitiesList.length === 0 && (
               <p className="italic text-slate-500 col-span-full mb-2">No loans added</p>
             )}
             {liabilitiesList.map(l => (
-              <div key={l.id} className="grid grid-cols-1 sm:grid-cols-7 gap-2 items-center mb-1">
+              <div key={l.id} className="grid grid-cols-1 sm:grid-cols-8 gap-2 items-center mb-1">
                 <div>
                   <label htmlFor={`liab-name-${l.id}`} className="sr-only">Liability name</label>
                   <input
@@ -836,6 +842,17 @@ export default function ExpensesGoalsTab() {
                     onChange={ev => handleLiabilityChange(l.id, 'extraPayment', ev.target.value)}
                     aria-label="Extra payment"
                   />
+                </div>
+                <div className="flex items-center mt-6 sm:mt-0">
+                  <input
+                    id={`liab-include-${l.id}`}
+                    type="checkbox"
+                    className="mr-1"
+                    checked={l.include !== false}
+                    onChange={ev => handleLiabilityChange(l.id, 'include', ev.target.checked)}
+                    aria-label="Include liability"
+                  />
+                  <label htmlFor={`liab-include-${l.id}`} className="text-sm">Include</label>
                 </div>
                 <button
                   onClick={() => removeLiability(l.id)}

--- a/src/components/ExpensesGoals/defaults.js
+++ b/src/components/ExpensesGoals/defaults.js
@@ -11,6 +11,7 @@ export function defaultExpenses(start, end) {
       growth: 0,
       category: 'Fixed',
       priority: 1,
+      include: true,
       startYear: start,
       endYear: end,
     },
@@ -23,6 +24,7 @@ export function defaultExpenses(start, end) {
       growth: 0,
       category: 'Variable',
       priority: 2,
+      include: true,
       startYear: start,
       endYear: end,
     },
@@ -51,6 +53,7 @@ export function defaultLiabilities(start) {
     termYears: 5,
     paymentsPerYear: 12,
     extraPayment: 0,
+    include: true,
     startYear: start,
     endYear: start + 4,
   }

--- a/src/schemas/expenseGoalSchemas.js
+++ b/src/schemas/expenseGoalSchemas.js
@@ -30,6 +30,7 @@ export const expenseItemSchema = z
     growth: numField().default(0),
     category: z.string().default(''),
     priority: intFieldWithRange(1, 3).default(2),
+    include: z.boolean().optional().default(true),
     startYear: intField(),
     endYear: intField().optional().nullable(),
   })


### PR DESCRIPTION
## Summary
- allow toggling expenses in PV calcs via new checkbox
- store `include` for liabilities too
- filter excluded items from PV metrics and timeline

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68556d0ac9008323bd71af8e5efd99de