### PR TITLE
Update expense categories and chart

### DIFF
--- a/src/components/ExpenseRow.jsx
+++ b/src/components/ExpenseRow.jsx
@@ -60,7 +60,7 @@ export default function ExpenseRow({ id, name, amount, frequency, category, star
           onChange={e => onChange(id, 'category', e.target.value)}
         >
           <option value="Fixed">Fixed</option>
-          <option value="Discretionary">Discretionary</option>
+          <option value="Variable">Variable</option>
           <option value="Other">Other</option>
         </select>
       </div>

--- a/src/components/ExpensesGoals/defaults.js
+++ b/src/components/ExpensesGoals/defaults.js
@@ -28,6 +28,19 @@ export function defaultExpenses(start, end) {
       startYear: start,
       endYear: end,
     },
+    {
+      id: crypto.randomUUID(),
+      name: 'Miscellaneous',
+      amount: 100,
+      frequency: 'Monthly',
+      paymentsPerYear: 12,
+      growth: 0,
+      category: 'Other',
+      priority: 3,
+      include: true,
+      startYear: start,
+      endYear: end,
+    },
   ]
 }
 

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -54,8 +54,9 @@ export default function ExpensesStackedBarChart() {
           <Tooltip />
           <Legend formatter={(value) => value} />
           <Bar dataKey="Fixed" stackId="a" fill="#1f77b4" />
-          <Bar dataKey="Discretionary" stackId="a" fill="#ff7f0e" />
-          <Bar dataKey="Goal" stackId="a" fill="#2ca02c" />
+          <Bar dataKey="Variable" stackId="a" fill="#ff7f0e" />
+          <Bar dataKey="Other" stackId="a" fill="#2ca02c" />
+          <Bar dataKey="Goal" stackId="a" fill="#9467bd" />
         </BarChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- add `Miscellaneous` sample expense
- drop Discretionary option in `ExpenseRow` and replace with `Variable`
- show `Other` on expenses chart

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68559a9264588323b923abf151e082d5