### PR TITLE
Remove timeline PV calculation

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -467,16 +467,18 @@ export default function ExpensesGoalsTab() {
   )
 
   useEffect(() => {
-    const expPV = timelineData.reduce((sum, r) => sum + r.expenses, 0)
-    const goalPV = timelineData.reduce((sum, r) => sum + r.goals, 0)
-    const loanPV = timelineData.reduce((s, r) => s + r.loans, 0)
-    setExpensesPV(expPV)
-    if (typeof setGoalsPV === 'function') setGoalsPV(goalPV)
-    storage.set('expensesPV', expPV.toString())
-    storage.set('goalsPV', goalPV.toString())
-    storage.set('loansPV', loanPV.toString())
-    storage.set('totalPV', (expPV + goalPV + loanPV).toString())
-  }, [timelineData, setExpensesPV, setGoalsPV])
+    if (typeof setGoalsPV === 'function') setGoalsPV(pvGoals)
+    storage.set('goalsPV', pvGoals.toString())
+  }, [pvGoals, setGoalsPV])
+
+  useEffect(() => {
+    storage.set('loansPV', totalLiabilitiesPV.toString())
+  }, [totalLiabilitiesPV])
+
+  useEffect(() => {
+    const totalPV = pvExpensesLife + pvGoals + totalLiabilitiesPV
+    storage.set('totalPV', totalPV.toString())
+  }, [pvExpensesLife, pvGoals, totalLiabilitiesPV])
 
   // --- 5) PV Summary data ---
   const pvSummaryData = [


### PR DESCRIPTION
## Summary
- refactor PV summary calculations in `ExpensesGoalsTab`
- use discounted PV values from `pvExpensesLife`, `pvGoals`, and `totalLiabilitiesPV`
- keep localStorage in sync with updated PV totals

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6857c21ba1b08323aec83d0322b33ffe