### PR TITLE
Fix loan schedule frequency

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -359,12 +359,12 @@ export default function ExpensesGoalsTab() {
   // --- 4) Loan details & amortization ---
   const liabilityDetails = useMemo(() => {
     return liabilitiesList.filter(l => l.include !== false).map(l => {
-      const ratePerPeriod = (Number(l.interestRate) || 0) / 100 / l.paymentsPerYear
       const start = new Date((l.startYear ?? currentYear), 0, 1).getTime()
       const sched = calculateLoanSchedule({
         principal: Number(l.principal) || 0,
-        annualRate: ratePerPeriod * 12,
-        termYears: (Number(l.termYears) || 0) * l.paymentsPerYear / 12,
+        annualRate: (Number(l.interestRate) || 0) / 100,
+        termYears: Number(l.termYears) || 0,
+        paymentsPerYear: l.paymentsPerYear,
         extraPayment: Number(l.extraPayment) || 0
       }, start)
       const pv = presentValue(

--- a/src/modules/loan/loan.test.js
+++ b/src/modules/loan/loan.test.js
@@ -7,6 +7,7 @@ test('loan amortization works', () => {
     principal: 200000,
     annualRate: 0.045,
     termYears: 30,
+    paymentsPerYear: 12,
     extraPayment: 200
   }, start)
   expect(schedule.payments.length).toBeGreaterThan(0)

--- a/src/modules/loan/loanCalculator.js
+++ b/src/modules/loan/loanCalculator.js
@@ -7,24 +7,28 @@ import { presentValue } from '../../utils/financeUtils'
  * @returns {import('./loanTypes').LoanSchedule}
  */
 export function calculateLoanSchedule(input, startDate = Date.now()) {
-  const mRate = input.annualRate / 12
-  const n = input.termYears * 12
-  const basePay = input.principal * (mRate / (1 - Math.pow(1 + mRate, -n)))
+  const ppy = input.paymentsPerYear ?? 12
+  const rate = input.annualRate / ppy
+  const n = input.termYears * ppy
+  const basePay = rate === 0
+    ? input.principal / n
+    : input.principal * (rate / (1 - Math.pow(1 + rate, -n)))
   let balance = input.principal
   let totalInterest = 0
   const payments = []
   const start = new Date(startDate).getTime()
+  const periodDays = 365 / ppy
   for (let i = 1; i <= n && balance > 0; i++) {
-    const interest = balance * mRate
+    const interest = balance * rate
     const extra = input.extraPayment || 0
     let principalPaid = basePay - interest + extra
     if (principalPaid > balance) principalPaid = balance
     const payment = interest + principalPaid
     balance -= principalPaid
     totalInterest += interest
-    const date = new Date(start + 864e5 * 30 * i).toISOString()
+    const date = new Date(start + 864e5 * periodDays * i).toISOString()
     payments.push({ date, payment, principalPaid, interestPaid: interest, balance })
   }
-  const pvLiability = presentValue(payments.map(p => p.payment), mRate)
+  const pvLiability = presentValue(payments.map(p => p.payment), rate)
   return { payments, totalInterest, pvLiability }
 }

--- a/src/modules/loan/loanTypes.js
+++ b/src/modules/loan/loanTypes.js
@@ -3,7 +3,8 @@
  * @property {number} principal - loan amount
  * @property {number} annualRate - annual interest rate (decimal)
  * @property {number} termYears - term in years
- * @property {number} [extraPayment] - optional extra payment each month
+ * @property {number} paymentsPerYear - payment frequency per year
+ * @property {number} [extraPayment] - optional extra payment each period
  */
 
 /**


### PR DESCRIPTION
## Summary
- support paymentsPerYear in loan schedule generator
- simplify liability calculations to use native frequency
- update amortization test for new param

## Testing
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857c3c413a083238bfd686763e398af