### PR TITLE
Modify expense charts

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -12,8 +12,6 @@ import sanitize from '../../utils/sanitize'
 import { expenseItemSchema, goalItemSchema } from '../../schemas/expenseGoalSchemas.js'
 import { frequencyToPayments } from '../../utils/financeUtils'
 import { calculateAmortizedPayment } from '../../utils/financeUtils'
-import { ResponsiveContainer } from 'recharts'
-import LifetimeStackedChart from './LifetimeStackedChart'
 import ExpensesStackedBarChart from '../ExpensesStackedBarChart.jsx'
 import buildTimeline from '../../selectors/timeline'
 import { annualAmountForYear } from '../../utils/streamHelpers'
@@ -545,10 +543,7 @@ export default function ExpensesGoalsTab() {
   const INTEREST_COLOR  = '#f87171'
   return (
     <div className="space-y-8 p-6">
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <ResponsiveContainer width="100%" height={400} role="img" aria-label="Cashflow timeline chart">
-          <LifetimeStackedChart data={timelineData} locale={settings.locale} currency={settings.currency} />
-        </ResponsiveContainer>
+      <section className="grid grid-cols-1 gap-6">
         <ExpensesStackedBarChart />
       </section>
 


### PR DESCRIPTION
## Summary
- drop timeline chart on the Expenses tab
- compute present value for bar chart data

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857c95b1e888323be4e28d17cb8b5dc