### PR TITLE
Remove redundant expenses line chart

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -13,7 +13,6 @@ import { expenseItemSchema, goalItemSchema } from '../../schemas/expenseGoalSche
 import { frequencyToPayments } from '../../utils/financeUtils'
 import { calculateAmortizedPayment } from '../../utils/financeUtils'
 import { ResponsiveContainer } from 'recharts'
-import LifetimeStackedChart from './LifetimeStackedChart'
 import ExpensesStackedBarChart from '../ExpensesStackedBarChart.jsx'
 import buildTimeline from '../../selectors/timeline'
 import { annualAmountForYear } from '../../utils/streamHelpers'
@@ -545,10 +544,7 @@ export default function ExpensesGoalsTab() {
   const INTEREST_COLOR  = '#f87171'
   return (
     <div className="space-y-8 p-6">
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <ResponsiveContainer width="100%" height={400} role="img" aria-label="Cashflow timeline chart">
-          <LifetimeStackedChart data={timelineData} locale={settings.locale} currency={settings.currency} />
-        </ResponsiveContainer>
+      <section className="grid grid-cols-1 gap-6">
         <ExpensesStackedBarChart />
       </section>
 


### PR DESCRIPTION
## Summary
- delete the lifetime cashflow chart from the Expenses tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d07ba6f88323afce344490e763c5