### PR TITLE
Wrap chart in responsive container

### DIFF
--- a/src/components/Income/IncomeTimelineChart.jsx
+++ b/src/components/Income/IncomeTimelineChart.jsx
@@ -1,19 +1,30 @@
 import React from 'react'
-import { BarChart, Bar, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import {
+  BarChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
 
 export default function IncomeTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <BarChart data={data} width={1000} height={500} role="img" aria-label="Income timeline chart">
-      <XAxis dataKey="year" />
-      <YAxis />
-      <Tooltip formatter={format} />
-      <Legend />
-      <Bar dataKey="gross" stackId="a" fill="#f59e0b" name="Gross Income" />
-      <Bar dataKey="net" stackId="a" fill="#16a34a" name="After Tax" />
-      <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" />
-    </BarChart>
+    <ResponsiveContainer width="100%" height={400} role="img" aria-label="Income timeline chart">
+      <BarChart data={data}>
+        <XAxis dataKey="year" />
+        <YAxis />
+        <Tooltip formatter={format} />
+        <Legend />
+        <Bar dataKey="gross" stackId="a" fill="#f59e0b" name="Gross Income" />
+        <Bar dataKey="net" stackId="a" fill="#16a34a" name="After Tax" />
+        <Line type="monotone" dataKey="expenses" stroke="#ef4444" name="Expenses" />
+      </BarChart>
+    </ResponsiveContainer>
   )
 }


### PR DESCRIPTION
## Summary
- wrap the income timeline chart inside ResponsiveContainer
- drop hardcoded width/height on BarChart

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars in src/components/Income/helpers.js)*

------
https://chatgpt.com/codex/tasks/task_e_68583fdf5b7c83238cd3a1c0a95d11cb