### PR TITLE
Add debt service aggregation to expense chart

### DIFF
--- a/src/__tests__/loanHelpers.test.js
+++ b/src/__tests__/loanHelpers.test.js
@@ -1,0 +1,35 @@
+import { generateRecurringFlows } from '../utils/financeUtils'
+import { getLoanFlowsByYear } from '../utils/loanHelpers'
+
+test('loan amounts added to chart data when liabilities exist', () => {
+  const start = 2024
+  const expenses = [{ amount: 100, paymentsPerYear: 12, growth: 0, startYear: start, endYear: start, category: 'Fixed', priority: 1 }]
+  const liabilities = [{ principal: 1200, interestRate: 12, termYears: 1, paymentsPerYear: 12, startYear: start, include: true }]
+
+  const dataByYear = {}
+  expenses.forEach(exp => {
+    const flows = generateRecurringFlows({
+      amount: exp.amount,
+      paymentsPerYear: exp.paymentsPerYear,
+      growth: 0,
+      startYear: exp.startYear,
+      endYear: exp.endYear,
+    })
+    flows.forEach(({ year, amount }) => {
+      if (!dataByYear[year]) dataByYear[year] = { year: String(year) }
+      dataByYear[year][exp.category] = (dataByYear[year][exp.category] || 0) + amount
+    })
+  })
+
+  const loanFlows = getLoanFlowsByYear(liabilities)
+  Object.entries(loanFlows).forEach(([year, amt]) => {
+    const y = Number(year)
+    if (!dataByYear[y]) dataByYear[y] = { year: String(y) }
+    dataByYear[y]['Debt Service'] = (dataByYear[y]['Debt Service'] || 0) + amt
+  })
+
+  const chartData = Object.values(dataByYear)
+  expect(chartData[0]['Debt Service']).toBeGreaterThan(0)
+})
+
+

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -14,11 +14,13 @@ import {
   generateRecurringFlows,
   frequencyToPayments,
 } from '../utils/financeUtils'
+import { getLoanFlowsByYear } from '../utils/loanHelpers'
 
 export default function ExpensesStackedBarChart() {
   const {
     expensesList,
     goalsList,
+    liabilitiesList,
     includeMediumPV,
     includeLowPV,
     includeGoalsPV,
@@ -29,6 +31,7 @@ export default function ExpensesStackedBarChart() {
     Variable: '#ff7f0e',
     Other: '#2ca02c',
     Goal: '#9467bd',
+    'Debt Service': '#34d399',
   }
 
   const PALETTE = [
@@ -81,6 +84,13 @@ export default function ExpensesStackedBarChart() {
     })
   }
 
+  const loanFlows = getLoanFlowsByYear(liabilitiesList)
+  Object.entries(loanFlows).forEach(([year, amt]) => {
+    const y = Number(year)
+    if (!dataByYear[y]) dataByYear[y] = { year: String(y) }
+    dataByYear[y]['Debt Service'] = (dataByYear[y]['Debt Service'] || 0) + amt
+  })
+
   const chartData = Object.values(dataByYear).sort((a, b) => a.year - b.year)
 
   const categories = useMemo(() => {
@@ -120,6 +130,9 @@ export default function ExpensesStackedBarChart() {
           {categories.map(cat => (
             <Bar key={cat} dataKey={cat} stackId="a" fill={colorMap[cat]} />
           ))}
+          {Object.keys(loanFlows).length > 0 && (
+            <Bar dataKey="Debt Service" stackId="a" fill="#34d399" />
+          )}
         </BarChart>
       </ResponsiveContainer>
     </div>

--- a/src/utils/loanHelpers.js
+++ b/src/utils/loanHelpers.js
@@ -1,0 +1,33 @@
+import { calculateLoanSchedule } from '../modules/loan/loanCalculator.js'
+
+/**
+ * Aggregate loan payments by calendar year.
+ *
+ * @param {Object[]} liabilitiesList - Array of liability objects
+ * @returns {Record<string, number>} map of year to total payments
+ */
+export function getLoanFlowsByYear(liabilitiesList = []) {
+  const totals = {}
+  liabilitiesList.forEach(l => {
+    if (!l || l.include === false) return
+    const startYear = Number(l.startYear) || new Date().getFullYear()
+    const schedule = calculateLoanSchedule({
+      principal: Number(l.principal) || 0,
+      annualRate: Number(l.interestRate) / 100 || 0,
+      termYears: Number(l.termYears) ||
+        (typeof l.endYear === 'number' && typeof l.startYear === 'number'
+          ? l.endYear - l.startYear + 1
+          : 1),
+      paymentsPerYear: Number(l.paymentsPerYear) || 12,
+      extraPayment: Number(l.extraPayment) || 0,
+    }, new Date(startYear, 0, 1))
+
+    schedule.payments.forEach(p => {
+      const year = new Date(p.date).getFullYear()
+      totals[year] = (totals[year] || 0) + p.payment
+    })
+  })
+  return totals
+}
+
+export default { getLoanFlowsByYear }


### PR DESCRIPTION
## Summary
- implement `getLoanFlowsByYear` helper for loan schedules
- include yearly debt service amounts in `ExpensesStackedBarChart`
- display an additional Debt Service bar in the chart
- test that loan amounts show up in chart data

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68590a863d84832399e3e0a82054d694