### PR TITLE
Default expense growth uses inflation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ This ensures that ESLint and Jest are available locally.
 
 ## Configuration
 
-Application settings are stored in local storage and can be modified under the **Settings** tab.  Available keys include:
+-Application settings are stored in local storage and can be modified under the **Settings** tab.  Available keys include:
 
-- `inflationRate` – stored for reference only; PV calculations use nominal growth
+- `inflationRate` – annual rate applied to expenses when no specific growth is set
 - `expectedReturn` – expected yearly portfolio return
 - `currency` – default ISO currency code
 - `locale` – locale for number formatting

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -49,7 +49,7 @@ export function FinanceProvider({ children }) {
           return parsed.projectionYears
         }
       }
-    } catch {}
+    } catch { /* ignore parse error */ }
     try {
       const pStr = storage.get('profile')
       if (pStr) {
@@ -58,7 +58,7 @@ export function FinanceProvider({ children }) {
           return Math.max(1, p.lifeExpectancy - p.age)
         }
       }
-    } catch {}
+    } catch { /* ignore parse error */ }
     return 85 - 30
   })
   const [monthlyExpense, setMonthlyExpense] = useState(() => {
@@ -747,7 +747,7 @@ export function FinanceProvider({ children }) {
     const rate = settings.discountRate ?? discountRate
     const horizonEnd = startYear + years - 1
     const totalPv = expensesList.reduce((sum, exp) => {
-      const growth = exp.growth || 0
+      const growth = exp.growth ?? settings.inflationRate
       const s = exp.startYear ?? startYear
       const e = exp.endYear ?? horizonEnd
       const first = Math.max(s, startYear)

--- a/src/__tests__/cashflowTimeline.compat.test.js
+++ b/src/__tests__/cashflowTimeline.compat.test.js
@@ -86,7 +86,7 @@ test('buildCashflowTimeline matches previous implementation', () => {
   const expenses = [{ amount: 100, paymentsPerYear: 12, growth: 0, startYear: 2024, endYear: 2025 }]
   const goals = [{ amount: 500, targetYear: 2025 }]
   const loans = y => (y === 2025 ? 200 : 0)
-  const newRes = buildCashflowTimeline(2024, 2025, incomeFn, expenses, goals, loans)
+  const newRes = buildCashflowTimeline(2024, 2025, incomeFn, expenses, goals, loans, 0)
   const oldRes = oldBuildTimeline(2024, 2025, incomeFn, expenses, goals, loans)
   expect(newRes).toEqual(oldRes)
 })

--- a/src/__tests__/chartSpan.test.js
+++ b/src/__tests__/chartSpan.test.js
@@ -6,6 +6,6 @@ test('timeline spans retirement horizon when expenses extend forward', () => {
   const expenses = [
     { amount: 100, paymentsPerYear: 12, startYear: current, endYear: retirementYear }
   ]
-  const timeline = buildTimeline(current, retirementYear, () => 0, expenses, [])
+  const timeline = buildTimeline(current, retirementYear, () => 0, expenses, [], undefined, 0)
   expect(timeline).toHaveLength(retirementYear - current + 1)
 })

--- a/src/__tests__/expensesGoals.pvUpdate.test.js
+++ b/src/__tests__/expensesGoals.pvUpdate.test.js
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import { FinanceProvider } from '../FinanceContext'
 import ExpensesGoalsTab from '../components/ExpensesGoals/ExpensesGoalsTab'
 import { formatCurrency } from '../utils/formatters'
+import { calculatePV } from '../utils/financeUtils'
 
 beforeAll(() => {
   global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
@@ -36,7 +37,8 @@ test('adding an expense updates PV totals', async () => {
 
   const profile = JSON.parse(localStorage.getItem('profile'))
   const years = profile.lifeExpectancy - profile.age
-  const expectedVal = formatCurrency(100 * 12 * years, 'en-US', 'KES').replace('KES', '')
+  const expectedPV = calculatePV(100, 12, 5, 0, years)
+  const expectedVal = formatCurrency(expectedPV, 'en-US', 'KES').replace('KES', '')
   await waitFor(() => {
     expect(valueNode.textContent).toContain(expectedVal.trim())
   })

--- a/src/__tests__/pvNominalGrowth.test.js
+++ b/src/__tests__/pvNominalGrowth.test.js
@@ -53,3 +53,20 @@ test('expense PV uses nominal growth rate', () => {
   const expected = calculatePV(500, 1, 4, 8, 5)
   expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(expected)
 })
+
+test('expense PV defaults to inflation rate when growth missing', () => {
+  const current = new Date().getFullYear()
+  localStorage.setItem('settings', JSON.stringify({ discountRate: 5, inflationRate: 2, startYear: current }))
+  localStorage.setItem('expensesList', JSON.stringify([
+    { name: 'Rent', amount: 1000, frequency: 1, startYear: current }
+  ]))
+
+  render(
+    <FinanceProvider>
+      <ExpensePV years={2} />
+    </FinanceProvider>
+  )
+
+  const expected = calculatePV(1000, 1, 2, 5, 2)
+  expect(Number(screen.getByTestId('pv').textContent)).toBeCloseTo(expected)
+})

--- a/src/__tests__/timeline.test.js
+++ b/src/__tests__/timeline.test.js
@@ -6,7 +6,9 @@ test('goal added only in target year when startYear equals endYear', () => {
     2026,
     () => 0,
     [],
-    [{ amount: 300, startYear: 2025, endYear: 2025, targetYear: 2025 }]
+    [{ amount: 300, startYear: 2025, endYear: 2025, targetYear: 2025 }],
+    undefined,
+    0
   )
   const goals = timeline.map(r => r.goals)
   expect(goals).toEqual([0, 300, 0])
@@ -18,7 +20,9 @@ test('multi-year goal occurs only in target year', () => {
     2026,
     () => 0,
     [],
-    [{ amount: 300, startYear: 2024, endYear: 2026, targetYear: 2026 }]
+    [{ amount: 300, startYear: 2024, endYear: 2026, targetYear: 2026 }],
+    undefined,
+    0
   )
   const goals = timeline.map(r => r.goals)
   expect(goals).toEqual([0, 0, 300])
@@ -30,7 +34,9 @@ test('string frequency expands to correct payments per year', () => {
     2024,
     () => 0,
     [{ amount: 100, frequency: 'Monthly', startYear: 2024, endYear: 2024 }],
-    []
+    [],
+    undefined,
+    0
   )
   expect(timeline[0].expenses).toBe(1200)
 })
@@ -41,7 +47,22 @@ test('unknown frequency defaults to single payment', () => {
     2024,
     () => 0,
     [{ amount: 100, frequency: 'Weekly', startYear: 2024, endYear: 2024 }],
-    []
+    [],
+    undefined,
+    0
   )
   expect(timeline[0].expenses).toBe(100)
+})
+
+test('expenses grow by inflation rate when growth not set', () => {
+  const timeline = buildTimeline(
+    2024,
+    2025,
+    () => 0,
+    [{ amount: 100, paymentsPerYear: 12, startYear: 2024, endYear: 2025 }],
+    [],
+    undefined,
+    5
+  )
+  expect(timeline[1].expenses).toBeCloseTo(timeline[0].expenses * 1.05)
 })

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -92,7 +92,7 @@ export default function ExpensesGoalsTab() {
   // Populate defaults on first mount when no data is present
   useEffect(() => {
     if (expensesList.length === 0) {
-      const list = defaultExpenses(defaultStart, defaultEnd)
+      const list = defaultExpenses(defaultStart, defaultEnd, settings.inflationRate)
       setExpensesList(list)
       storage.set('expensesList', JSON.stringify(list))
     }
@@ -183,7 +183,7 @@ export default function ExpensesGoalsTab() {
         amount: 0,
         frequency: 'Monthly',
         paymentsPerYear: 12,
-        growth: 0,
+        growth: settings.inflationRate,
         category: 'Fixed',
         priority: 2,
         include: true,
@@ -309,7 +309,7 @@ export default function ExpensesGoalsTab() {
   }
 
   const resetDefaults = () => {
-    setExpensesList(defaultExpenses(defaultStart, defaultEnd))
+    setExpensesList(defaultExpenses(defaultStart, defaultEnd, settings.inflationRate))
     setGoalsList(defaultGoals(defaultStart))
     setLiabilitiesList(defaultLiabilities(defaultStart))
   }
@@ -326,7 +326,7 @@ export default function ExpensesGoalsTab() {
       const first = Math.max(start, currentYear)
       const last = Math.min(end, horizonEnd)
       if (last < first) return sum
-      const growth = e.growth || 0
+      const growth = e.growth ?? settings.inflationRate
       let pv = 0
       const ppy = e.paymentsPerYear || frequencyToPayments(e.frequency) || 1
       for (let yr = first; yr <= last; yr++) {
@@ -337,7 +337,7 @@ export default function ExpensesGoalsTab() {
       }
       return sum + pv
     }, 0)
-  }, [filteredExpenses, discountRate, lifeYears, currentYear])
+  }, [filteredExpenses, discountRate, lifeYears, currentYear, settings.inflationRate])
 
   useEffect(() => {
     setExpensesPV(pvExpensesLife)
@@ -419,7 +419,8 @@ export default function ExpensesGoalsTab() {
       incomeFn,
       filteredExpenses,
       filteredGoals,
-      loanForYear
+      loanForYear,
+      settings.inflationRate
     )
     let running = 0
     return rows.map(row => {
@@ -454,6 +455,7 @@ export default function ExpensesGoalsTab() {
     retirementYear,
     profile.age,
     profile.lifeExpectancy,
+    settings.inflationRate,
   ])
 
   const maxSurplus = useMemo(() => {

--- a/src/components/ExpensesGoals/defaults.js
+++ b/src/components/ExpensesGoals/defaults.js
@@ -1,6 +1,6 @@
 import { calculateAmortizedPayment } from '../../utils/financeUtils.js'
 
-export function defaultExpenses(start, end) {
+export function defaultExpenses(start, end, inflation = 0) {
   return [
     {
       id: crypto.randomUUID(),
@@ -8,7 +8,7 @@ export function defaultExpenses(start, end) {
       amount: 1200,
       frequency: 'Monthly',
       paymentsPerYear: 12,
-      growth: 0,
+      growth: inflation,
       category: 'Fixed',
       priority: 1,
       include: true,
@@ -21,7 +21,7 @@ export function defaultExpenses(start, end) {
       amount: 300,
       frequency: 'Monthly',
       paymentsPerYear: 12,
-      growth: 0,
+      growth: inflation,
       category: 'Variable',
       priority: 2,
       include: true,
@@ -34,7 +34,7 @@ export function defaultExpenses(start, end) {
       amount: 100,
       frequency: 'Monthly',
       paymentsPerYear: 12,
-      growth: 0,
+      growth: inflation,
       category: 'Other',
       priority: 3,
       include: true,

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -24,6 +24,7 @@ export default function ExpensesStackedBarChart() {
     includeMediumPV,
     includeLowPV,
     includeGoalsPV,
+    settings,
   } = useFinance()
 
   const BASE_COLORS = {
@@ -62,7 +63,7 @@ export default function ExpensesStackedBarChart() {
           : typeof exp.frequency === 'number'
             ? exp.frequency
             : frequencyToPayments(exp.frequency),
-      growth: Number(exp.growth) || 0,
+      growth: Number(exp.growth ?? settings.inflationRate) || 0,
       startYear: exp.startYear,
       endYear: exp.endYear ?? exp.startYear,
     })

--- a/src/components/Income/helpers.js
+++ b/src/components/Income/helpers.js
@@ -1,5 +1,5 @@
 import { getStreamEndYear } from '../../utils/incomeProjection'
-import { calculatePV as calcPV, generateRecurringFlows, frequencyToPayments } from '../../utils/financeUtils'
+import { calculatePV as calcPV, frequencyToPayments } from '../../utils/financeUtils'
 
 export function findLinkedAsset(id, assetsList = []) {
   return assetsList.find(a => a.id === id)

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -9,6 +9,7 @@ const getYears = state => state.years || 1
 const getDiscountRate = state => state.settings?.discountRate ?? state.discountRate ?? 0
 const getRetirementAge = state => state.settings?.retirementAge ?? 65
 const getCurrentAge = state => state.profile?.age ?? 0
+const getInflationRate = state => state.settings?.inflationRate ?? 0
 
 export const selectAnnualIncome = createSelector(
   [getIncomeSources, getStartYear, getYears, getRetirementAge, getCurrentAge],
@@ -45,14 +46,14 @@ export const selectAnnualIncomePV = createSelector(
 )
 
 export const selectAnnualOutflow = createSelector(
-  [getExpenses, getGoals, getStartYear, getYears],
-  (expenses, goals, startYear, years) => {
+  [getExpenses, getGoals, getStartYear, getYears, getInflationRate],
+  (expenses, goals, startYear, years, inflationRate) => {
     return Array.from({ length: years }, (_, idx) => {
       const year = startYear + idx
       const horizonEnd = startYear + years - 1
       const expTotal = expenses.reduce((sum, e) => {
         const ppy = e.paymentsPerYear || frequencyToPayments(e.frequency) || 1
-        const growth = e.growth || 0
+        const growth = e.growth ?? inflationRate
         const s = e.startYear ?? startYear
         const end = e.endYear ?? horizonEnd
         if (year < s || year > end) return sum

--- a/src/utils/cashflowTimeline.js
+++ b/src/utils/cashflowTimeline.js
@@ -48,7 +48,8 @@ export function buildCashflowTimeline(
   incomeFn,
   expensesList,
   goalsList,
-  getLoansForYear = () => 0
+  getLoansForYear = () => 0,
+  inflationRate = 0
 ) {
   const timeline = [];
   let prevSurplus = 0;
@@ -66,7 +67,7 @@ export function buildCashflowTimeline(
           typeof e.paymentsPerYear === 'number'
             ? e.paymentsPerYear
             : frequencyToPayments(e.frequency) || 1;
-        const growth = e.growth || 0;
+        const growth = e.growth ?? inflationRate;
         expenses += (Number(e.amount) || 0) * freq * Math.pow(1 + growth / 100, t);
       }
     });


### PR DESCRIPTION
## Summary
- apply inflation rate when creating default expenses or adding new ones
- compute expense PV and timelines using inflation rate when growth isn't set
- propagate inflation rate through selectors and stacked charts
- add unit tests confirming inflation-rate growth
- document inflation usage in README

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68590f645c20832391e0223d3c1a5267