### PR TITLE
Wrap CashflowTimelineChart in ResponsiveContainer

### DIFF
--- a/src/components/ExpensesGoals/CashflowTimelineChart.jsx
+++ b/src/components/ExpensesGoals/CashflowTimelineChart.jsx
@@ -1,17 +1,28 @@
 import React from 'react'
-import { AreaChart, Area, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts'
+import {
+  AreaChart,
+  Area,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
 import { formatCurrency } from '../../utils/formatters'
 
 export default function CashflowTimelineChart({ data = [], locale, currency }) {
   const format = v => formatCurrency(v, locale, currency)
   return (
-    <AreaChart data={data} width={1000} height={400} role="img" aria-label="Cashflow timeline chart">
-      <XAxis dataKey="year" />
-      <YAxis tickFormatter={format} />
-      <Tooltip formatter={format} />
-      <Legend />
-      <Area type="monotone" dataKey="surplus" stroke="#22c55e" fill="#bbf7d0" name="Surplus" />
-      <Line type="monotone" dataKey="net" stroke="#f59e0b" name="Net" />
-    </AreaChart>
+    <ResponsiveContainer width="100%" height={400} role="img" aria-label="Cashflow timeline chart">
+      <AreaChart data={data}>
+        <XAxis dataKey="year" />
+        <YAxis tickFormatter={format} />
+        <Tooltip formatter={format} />
+        <Legend />
+        <Area type="monotone" dataKey="surplus" stroke="#22c55e" fill="#bbf7d0" name="Surplus" />
+        <Line type="monotone" dataKey="net" stroke="#f59e0b" name="Net" />
+      </AreaChart>
+    </ResponsiveContainer>
   )
 }


### PR DESCRIPTION
## Summary
- make `CashflowTimelineChart` responsive like the other charts

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68591bf6c1b08323b210dd452ffe717b