### PR TITLE
Add PV toggle for income & expenses charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ Calling `submitProfile()` sends the generated JSON to the configured endpoint.
 ## Income Views
 
 Above the income chart you'll find **Nominal** and **Discounted** buttons. Use
-them to toggle between raw projections and present value figures. The discount
-rate and projection horizon (Years) are both configured under **Settings**.
+them to toggle between raw projections and present value figures. The expenses
+chart in **Expenses & Goals** offers the same controls. The discount rate and
+projection horizon (Years) are both configured under **Settings**.
 
 ## Manual Verification
 

--- a/src/__tests__/chartMode.discount.test.js
+++ b/src/__tests__/chartMode.discount.test.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import IncomeTab from '../components/Income/IncomeTab'
+import ExpensesGoalsTab from '../components/ExpensesGoals/ExpensesGoalsTab'
+
+jest.mock('recharts', () => {
+  const actual = jest.requireActual('recharts')
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }) => <div>{children}</div>,
+    BarChart: props => {
+      global.__chartData = props.data
+      return <div />
+    },
+    Bar: () => null,
+    XAxis: () => null,
+    YAxis: () => null,
+    CartesianGrid: () => null,
+    Tooltip: () => null,
+    Legend: () => null,
+  }
+})
+
+jest.mock('../components/Income/IncomeTimelineChart', () => ({
+  __esModule: true,
+  default: jest.fn(() => null)
+}))
+
+const IncomeTimelineChart = require('../components/Income/IncomeTimelineChart').default
+
+global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+
+afterEach(() => {
+  jest.clearAllMocks()
+  localStorage.clear()
+})
+
+function setupIncome() {
+  const now = 2024
+  localStorage.setItem('settings', JSON.stringify({ discountRate: 10, startYear: now, projectionYears: 2 }))
+  localStorage.setItem('incomeSources', JSON.stringify([
+    { name: 'Job', amount: 1000, frequency: 1, growth: 0, taxRate: 0, startYear: now, active: true }
+  ]))
+  return render(
+    <FinanceProvider>
+      <IncomeTab />
+    </FinanceProvider>
+  )
+}
+
+function setupExpenses() {
+  const now = 2024
+  localStorage.setItem('settings', JSON.stringify({ discountRate: 10, startYear: now }))
+  localStorage.setItem('expensesList', JSON.stringify([
+    { id:'e1', name:'Rent', amount: 120, frequency:'Annually', paymentsPerYear:1, growth:0, category:'Fixed', priority:1, include:true, startYear: now, endYear: now + 1 }
+  ]))
+  localStorage.setItem('goalsList', JSON.stringify([]))
+  localStorage.setItem('liabilitiesList', JSON.stringify([]))
+  localStorage.setItem('includeGoalsPV', 'false')
+  localStorage.setItem('includeLiabilitiesNPV', 'false')
+  return render(
+    <FinanceProvider>
+      <ExpensesGoalsTab />
+    </FinanceProvider>
+  )
+}
+
+test('income chart discounted mode lowers future values', () => {
+  setupIncome()
+  const nominalCall = IncomeTimelineChart.mock.calls.at(-1)[0]
+  const grossNominal = nominalCall.data[1].gross
+  fireEvent.click(screen.getByText('Discounted'))
+  const pvCall = IncomeTimelineChart.mock.calls.at(-1)[0]
+  const grossPV = pvCall.data[1].gross
+  expect(grossPV).toBeLessThan(grossNominal)
+})
+
+test('expenses chart discounted mode lowers future totals', () => {
+  setupExpenses()
+  const nominal = global.__chartData
+  const valNominal = nominal[1]['Fixed']
+  fireEvent.click(screen.getByText('Discounted'))
+  const discounted = global.__chartData
+  const valPV = discounted[1]['Fixed']
+  expect(valPV).toBeLessThan(valNominal)
+})

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -72,6 +72,7 @@ export default function ExpensesGoalsTab() {
   const [showAssumptions, setShowAssumptions] = useState(false)
   const [_expenseErrors, setExpenseErrors] = useState({})
   const [goalErrors, setGoalErrors] = useState({})
+  const [chartMode, setChartMode] = useState('nominal')
 
   const filteredExpenses = useMemo(
     () =>
@@ -548,7 +549,21 @@ export default function ExpensesGoalsTab() {
   return (
     <div className="space-y-8 p-6">
       <section className="grid grid-cols-1 gap-6">
-        <ExpensesStackedBarChart />
+        <div className="mb-2 space-x-2">
+          <button
+            className={`px-3 py-1 rounded ${chartMode === 'nominal' ? 'bg-amber-400 text-white' : 'bg-white border border-amber-400 text-amber-700'}`}
+            onClick={() => setChartMode('nominal')}
+          >
+            Nominal
+          </button>
+          <button
+            className={`px-3 py-1 rounded ${chartMode === 'pv' ? 'bg-amber-400 text-white' : 'bg-white border border-amber-400 text-amber-700'}`}
+            onClick={() => setChartMode('pv')}
+          >
+            Discounted
+          </button>
+        </div>
+        <ExpensesStackedBarChart chartMode={chartMode} />
       </section>
 
       <Card>


### PR DESCRIPTION
## Summary
- add nominal/discounted toggle to income chart
- support PV mode for expenses chart
- document chart mode toggles
- test PV chart switching

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68591e4f4808832391340049dd750e89