### PR TITLE
Add discount rate and projection years controls

### DIFF
--- a/src/__tests__/preferencesTab.test.js
+++ b/src/__tests__/preferencesTab.test.js
@@ -14,4 +14,6 @@ test('preferences tab renders correctly', () => {
     </FinanceProvider>
   );
   expect(screen.getByText(/Global Settings/i)).toBeInTheDocument();
+  expect(screen.getByTitle('Discount rate')).toBeInTheDocument();
+  expect(screen.getByTitle('Projection years')).toBeInTheDocument();
 });

--- a/src/tabs/PreferencesTab.jsx
+++ b/src/tabs/PreferencesTab.jsx
@@ -60,6 +60,36 @@ export default function PreferencesTab() {
           />
         </label>
 
+        {/* Discount Rate */}
+        <label className="block">
+          <span className="text-sm text-slate-600">Discount Rate (%)</span>
+          <input
+            type="number"
+            value={form.discountRate}
+            onChange={e => handleChange('discountRate', parseFloat(e.target.value) || 0)}
+            className="w-full border rounded-md p-2"
+            title="Discount rate"
+          />
+        </label>
+
+        {/* Projection Years */}
+        <label className="block">
+          <span className="text-sm text-slate-600">Projection Years</span>
+          <input
+            type="number"
+            min={1}
+            value={form.projectionYears}
+            onChange={e =>
+              handleChange(
+                'projectionYears',
+                Math.max(1, parseInt(e.target.value) || 1)
+              )
+            }
+            className="w-full border rounded-md p-2"
+            title="Projection years"
+          />
+        </label>
+
         {/* Currency */}
         <label className="block">
           <span className="text-sm text-slate-600">Default Currency</span>


### PR DESCRIPTION
## Summary
- include numeric inputs for discount rate and projection horizon
- verify Preferences tab renders new settings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d89c5f390832392e16cad5f126307