### PR TITLE
Add income defaults and reset options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Calling `submitProfile()` sends the generated JSON to the configured endpoint.
 
 Above the income chart you'll find **Nominal** and **Discounted** buttons used to toggle between raw projections and present value figures. The expenses chart in **Expenses & Goals** and the surplus (cashflow) chart on the **Balance Sheet** tab offer the same controls. Adjust the assumptions using the **Discount Rate (%)** and **Projection Years** fields under **Settings**.
 
+### Managing Income Sources
+The **Income** tab now includes **Clear** and **Reset Defaults** buttons next to the export options. Use **Clear** to remove all entries and **Reset Defaults** to insert a starter salary stream beginning in the selected start year.
+
 ## Manual Verification
 
 ### Verifying Charts

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -21,6 +21,7 @@ import { riskScoreMap } from './riskScoreConfig'
 import { deriveStrategy } from './utils/strategyUtils'
 import { getStreamEndYear } from './utils/incomeProjection'
 import storage from './utils/storage'
+import { defaultIncomeSources } from './components/Income/defaults.js'
 
 const DEFAULT_CURRENCY_MAP = {
   Kenyan: 'KES',
@@ -166,19 +167,7 @@ export function FinanceProvider({ children }) {
   const [incomeSources, setIncomeSources] = useState(() => {
     const s = storage.get('incomeSources')
     const now = new Date().getFullYear()
-    const defaults = [{
-      id: crypto.randomUUID(),
-      name: 'Salary',
-      type: 'Employment',
-      amount: 10000,
-      frequency: 12,
-      growth: 5,
-      taxRate: 30,
-      startYear: now,
-      endYear: null,
-      linkedAssetId: '',
-      active: true,
-    }]
+    const defaults = defaultIncomeSources(now)
     if (s) {
       try {
         const parsed = JSON.parse(s)

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -17,6 +17,7 @@ import { generateIncomeTimeline } from '../../utils/cashflowTimeline';
 import calcDiscretionaryAdvice from '../../utils/discretionaryUtils';
 import IncomeSourceRow from './IncomeSourceRow'
 import IncomeTimelineChart from './IncomeTimelineChart'
+import { defaultIncomeSources } from './defaults.js'
 
 import { formatCurrency } from '../../utils/formatters'
 import storage from '../../utils/storage'
@@ -217,14 +218,22 @@ export default function IncomeTab() {
         startYear: startYear,
         endYear: null,
         linkedAssetId: '',
-        active: true,
-      },
+      active: true,
+    },
     ]);
   };
 
   const removeIncome = (idx) => {
     setIncomeSources(incomeSources.filter((_, i) => i !== idx));
   };
+
+  const clearIncomeSources = () => {
+    setIncomeSources([])
+  }
+
+  const resetDefaults = () => {
+    setIncomeSources(defaultIncomeSources(startYear))
+  }
 
   const updateIncome = onFieldChange;
   const deleteIncome = removeIncome;
@@ -407,6 +416,23 @@ export default function IncomeTab() {
       {gaps.length > 0 && (
         <p className="text-red-600 font-bold mt-2">Warning: Income shortfall in {gaps[0].year} to {gaps[gaps.length - 1].year}</p>
       )}
+
+      <div className="text-right space-x-2">
+        <button
+          onClick={clearIncomeSources}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Clear income sources"
+        >
+          Clear
+        </button>
+        <button
+          onClick={resetDefaults}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Reset income sources to defaults"
+        >
+          Reset Defaults
+        </button>
+      </div>
 
       {/* Export */}
       <section>

--- a/src/components/Income/defaults.js
+++ b/src/components/Income/defaults.js
@@ -1,0 +1,17 @@
+export function defaultIncomeSources(start) {
+  return [
+    {
+      id: crypto.randomUUID(),
+      name: 'Salary',
+      type: 'Employment',
+      amount: 10000,
+      frequency: 12,
+      growth: 5,
+      taxRate: 30,
+      startYear: start,
+      endYear: null,
+      linkedAssetId: '',
+      active: true,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary
- add helper for default income sources
- initialize income state from helper
- allow clearing or resetting income sources
- document new income options

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685d9a253f488323b5829ad5931acfa7