### PR TITLE
Use persona data for reset defaults and add pension

### DIFF
--- a/public/hadiSeed.json
+++ b/public/hadiSeed.json
@@ -65,8 +65,9 @@
       "name": "Pension Drawdown",
       "amount": 180000,
       "frequency": 12,
-      "taxed": false
-    }    
+      "taxed": false,
+      "startAge": 65
+    }
   ],
   "expensesList": [
     {

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -92,17 +92,54 @@ export default function ExpensesGoalsTab() {
   // Populate defaults on first mount when no data is present
   useEffect(() => {
     if (expensesList.length === 0) {
-      const list = defaultExpenses(defaultStart, defaultEnd, settings.inflationRate)
+      let list
+      if (currentData?.expensesList?.length) {
+        list = currentData.expensesList.map(e => ({
+          id: crypto.randomUUID(),
+          paymentsPerYear: typeof e.frequency === 'number'
+            ? e.frequency
+            : frequencyToPayments(e.frequency) || 1,
+          startYear: e.startYear ?? defaultStart,
+          endYear: e.endYear ?? defaultEnd,
+          priority: e.priority ?? 2,
+          include: e.include !== false,
+          ...e,
+        }))
+      } else {
+        list = defaultExpenses(defaultStart, defaultEnd, settings.inflationRate)
+      }
       setExpensesList(list)
       storage.set('expensesList', JSON.stringify(list))
     }
     if (goalsList.length === 0) {
-      const list = defaultGoals(defaultStart)
+      let list
+      if (currentData?.goalsList?.length) {
+        list = currentData.goalsList.map(g => ({
+          id: crypto.randomUUID(),
+          startYear: g.startYear ?? g.targetYear ?? defaultStart,
+          endYear: g.endYear ?? g.targetYear ?? defaultStart,
+          ...g,
+        }))
+      } else {
+        list = defaultGoals(defaultStart)
+      }
       setGoalsList(list)
       storage.set('goalsList', JSON.stringify(list))
     }
     if (liabilitiesList.length === 0) {
-      const list = defaultLiabilities(defaultStart)
+      let list
+      if (currentData?.liabilitiesList?.length) {
+        list = currentData.liabilitiesList.map(l => ({
+          id: crypto.randomUUID(),
+          paymentsPerYear: l.paymentsPerYear ?? 12,
+          payment: l.monthlyPayment ?? l.payment,
+          termYears: l.termYears ?? Math.ceil((l.termMonths || 0) / 12),
+          include: l.include !== false,
+          ...l,
+        }))
+      } else {
+        list = defaultLiabilities(defaultStart)
+      }
       setLiabilitiesList(list)
       storage.set('liabilitiesList', JSON.stringify(list))
     }
@@ -309,9 +346,48 @@ export default function ExpensesGoalsTab() {
   }
 
   const resetDefaults = () => {
-    setExpensesList(defaultExpenses(defaultStart, defaultEnd, settings.inflationRate))
-    setGoalsList(defaultGoals(defaultStart))
-    setLiabilitiesList(defaultLiabilities(defaultStart))
+    if (currentData?.expensesList?.length) {
+      const list = currentData.expensesList.map(e => ({
+        id: crypto.randomUUID(),
+        paymentsPerYear: typeof e.frequency === 'number'
+          ? e.frequency
+          : frequencyToPayments(e.frequency) || 1,
+        startYear: e.startYear ?? defaultStart,
+        endYear: e.endYear ?? defaultEnd,
+        priority: e.priority ?? 2,
+        include: e.include !== false,
+        ...e,
+      }))
+      setExpensesList(list)
+    } else {
+      setExpensesList(defaultExpenses(defaultStart, defaultEnd, settings.inflationRate))
+    }
+
+    if (currentData?.goalsList?.length) {
+      const list = currentData.goalsList.map(g => ({
+        id: crypto.randomUUID(),
+        startYear: g.startYear ?? g.targetYear ?? defaultStart,
+        endYear: g.endYear ?? g.targetYear ?? defaultStart,
+        ...g,
+      }))
+      setGoalsList(list)
+    } else {
+      setGoalsList(defaultGoals(defaultStart))
+    }
+
+    if (currentData?.liabilitiesList?.length) {
+      const list = currentData.liabilitiesList.map(l => ({
+        id: crypto.randomUUID(),
+        paymentsPerYear: l.paymentsPerYear ?? 12,
+        payment: l.monthlyPayment ?? l.payment,
+        termYears: l.termYears ?? Math.ceil((l.termMonths || 0) / 12),
+        include: l.include !== false,
+        ...l,
+      }))
+      setLiabilitiesList(list)
+    } else {
+      setLiabilitiesList(defaultLiabilities(defaultStart))
+    }
   }
 
   // --- 1) Remaining lifetime horizon ---

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -11,6 +11,7 @@
 
 import React, { useMemo, useEffect, useState } from 'react';
 import { useFinance } from '../../FinanceContext';
+import { usePersona } from '../../PersonaContext.jsx';
 import { buildIncomeJSON, buildIncomeCSV, submitProfile } from '../../utils/exportHelpers'
 import { calculatePV, findLinkedAsset } from './helpers';
 import { generateIncomeTimeline } from '../../utils/cashflowTimeline';
@@ -38,6 +39,7 @@ export default function IncomeTab() {
     startYear,
     years,
   } = useFinance();
+  const { currentData } = usePersona();
 
 
   const currentYear = new Date().getFullYear();
@@ -232,7 +234,27 @@ export default function IncomeTab() {
   }
 
   const resetDefaults = () => {
-    setIncomeSources(defaultIncomeSources(startYear))
+    if (currentData?.incomeSources?.length) {
+      const now = new Date().getFullYear()
+      const birthYear = now - (profile.age ?? 0)
+      const list = currentData.incomeSources.map(src => {
+        let sYear = src.startYear ?? startYear
+        if (src.startAge != null) {
+          sYear = birthYear + src.startAge
+        }
+        return {
+          id: crypto.randomUUID(),
+          active: src.active !== false,
+          linkedAssetId: src.linkedAssetId ?? '',
+          ...src,
+          startYear: sYear,
+          endYear: src.endYear ?? null,
+        }
+      })
+      setIncomeSources(list)
+    } else {
+      setIncomeSources(defaultIncomeSources(startYear))
+    }
   }
 
   const updateIncome = onFieldChange;

--- a/src/data/personas.json
+++ b/src/data/personas.json
@@ -61,6 +61,12 @@
         "amount": 10000,
         "frequency": 12,
         "taxed": false
+      },
+      {
+        "name": "Pension Drawdown",
+        "amount": 180000,
+        "frequency": 12,
+        "startAge": 65
       }
     ],
     "expensesList": [


### PR DESCRIPTION
## Summary
- ensure reset buttons restore data from selected persona rather than generic defaults
- populate Hadi persona with Pension Drawdown income and expose startAge field
- propagate startAge in public seed file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685daaae829c83239c817d5ffd5b32d1