### PR TITLE
Handle open-ended expenses

### DIFF
--- a/src/__tests__/timeline.test.js
+++ b/src/__tests__/timeline.test.js
@@ -79,3 +79,16 @@ test('expense growth overrides inflation rate', () => {
   )
   expect(timeline[1].expenses).toBeCloseTo(timeline[0].expenses * 1.1)
 })
+
+test('expense without endYear persists through maxYear', () => {
+  const timeline = buildTimeline(
+    2024,
+    2026,
+    () => 0,
+    [{ amount: 100, paymentsPerYear: 1, startYear: 2024 }],
+    [],
+    undefined,
+    0
+  )
+  expect(timeline.map(r => r.expenses)).toEqual([100, 100, 100])
+})

--- a/src/components/ExpensesStackedBarChart.jsx
+++ b/src/components/ExpensesStackedBarChart.jsx
@@ -26,6 +26,7 @@ export default function ExpensesStackedBarChart({ chartMode = 'nominal' }) {
     includeGoalsPV,
     settings,
     startYear,
+    years,
   } = useFinance()
 
   const BASE_COLORS = {
@@ -49,6 +50,7 @@ export default function ExpensesStackedBarChart({ chartMode = 'nominal' }) {
 
   // Aggregate expenses by year and category
   const filtered = expensesList.filter(e => {
+    if (e.include === false) return false
     if (e.priority === 2 && !includeMediumPV) return false
     if (e.priority > 2 && !includeLowPV) return false
     return true
@@ -66,7 +68,7 @@ export default function ExpensesStackedBarChart({ chartMode = 'nominal' }) {
             : frequencyToPayments(exp.frequency),
       growth: Number(exp.growth ?? settings.inflationRate) || 0,
       startYear: exp.startYear,
-      endYear: exp.endYear ?? exp.startYear,
+      endYear: exp.endYear ?? startYear + years - 1,
     })
 
     flows.forEach(({ year, amount }) => {

--- a/src/utils/cashflowTimeline.js
+++ b/src/utils/cashflowTimeline.js
@@ -61,7 +61,9 @@ export function buildCashflowTimeline(
     const loans = getLoansForYear(y);
 
     expensesList.forEach(e => {
-      if (y >= e.startYear && y <= e.endYear) {
+      if (e.include === false) return;
+      const end = e.endYear ?? maxYear;
+      if (y >= e.startYear && y <= end) {
         const t = y - e.startYear;
         const freq =
           typeof e.paymentsPerYear === 'number'


### PR DESCRIPTION
## Summary
- support skipping excluded expenses in cashflow timeline
- end-year defaults to max year in cashflow timeline
- filter excluded expenses in ExpensesStackedBarChart
- use planning horizon end year for recurring flows
- test open-ended expense timelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db1268f6c832389b93e62c15a9e2e