### PR TITLE
Fix expense inclusion in outflow calculations

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -52,6 +52,7 @@ export const selectAnnualOutflow = createSelector(
       const year = startYear + idx
       const horizonEnd = startYear + years - 1
       const expTotal = expenses.reduce((sum, e) => {
+        if (e.include === false) return sum
         const ppy = e.paymentsPerYear || frequencyToPayments(e.frequency) || 1
         const growth = Number(e.growth ?? inflationRate) || 0
         const s = e.startYear ?? startYear


### PR DESCRIPTION
## Summary
- skip expenses marked as excluded when summing outflows
- mock recharts in expense exclusion tests
- check chart data updates when an expense is deselected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db2b2413c8323800a6c0cbfa8f94a