### PR TITLE
Add liability payment display

### DIFF
--- a/src/__tests__/expensesGoals.paymentDisplay.test.js
+++ b/src/__tests__/expensesGoals.paymentDisplay.test.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import ExpensesGoalsTab from '../components/ExpensesGoals/ExpensesGoalsTab'
+import { calculateAmortizedPayment } from '../utils/financeUtils'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function mount() {
+  const now = 2024
+  const payment = calculateAmortizedPayment(1200, 6, 1, 12)
+  const liability = {
+    id: 'l1',
+    name: 'Car Loan',
+    principal: 1200,
+    interestRate: 6,
+    termYears: 1,
+    paymentsPerYear: 12,
+    extraPayment: 0,
+    include: true,
+    startYear: now,
+    endYear: now,
+    computedPayment: payment,
+  }
+  localStorage.setItem('profile', JSON.stringify({ nationality: 'Kenyan', age: 30, lifeExpectancy: 80 }))
+  localStorage.setItem('expensesList', JSON.stringify([]))
+  localStorage.setItem('goalsList', JSON.stringify([]))
+  localStorage.setItem('liabilitiesList', JSON.stringify([liability]))
+  localStorage.setItem('includeGoalsPV', 'true')
+  localStorage.setItem('includeLiabilitiesNPV', 'true')
+
+  return render(
+    <FinanceProvider>
+      <ExpensesGoalsTab />
+    </FinanceProvider>
+  )
+}
+
+test('liability payment amount is displayed', async () => {
+  mount()
+  await screen.findByText('PV of Liabilities')
+  const val = calculateAmortizedPayment(1200, 6, 1, 12)
+  expect(screen.getByText(val.toFixed(0))).toBeInTheDocument()
+})

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -839,13 +839,14 @@ export default function ExpensesGoalsTab() {
         </CardHeader>
         {showLiabilities && (
           <CardBody>
-            <div className="grid grid-cols-1 sm:grid-cols-8 gap-2 font-semibold text-gray-700 mb-1">
+            <div className="grid grid-cols-1 sm:grid-cols-9 gap-2 font-semibold text-gray-700 mb-1">
               <div>Name</div>
               <div className="text-right">Principal</div>
               <div className="text-right">Rate %</div>
               <div className="text-right">Term</div>
               <div>Pay/Yr</div>
               <div className="text-right">Extra</div>
+              <div className="text-right">Pmt</div>
               <div>Include</div>
               <div></div>
             </div>
@@ -853,7 +854,7 @@ export default function ExpensesGoalsTab() {
               <p className="italic text-slate-500 col-span-full mb-2">No loans added</p>
             )}
             {liabilitiesList.map(l => (
-              <div key={l.id} className="grid grid-cols-1 sm:grid-cols-8 gap-2 items-center mb-1">
+              <div key={l.id} className="grid grid-cols-1 sm:grid-cols-9 gap-2 items-center mb-1">
                 <div>
                   <label htmlFor={`liab-name-${l.id}`} className="sr-only">Liability name</label>
                   <input
@@ -920,6 +921,7 @@ export default function ExpensesGoalsTab() {
                     aria-label="Extra payment"
                   />
                 </div>
+                <div className="text-right">{l.computedPayment?.toFixed(0)}</div>
                 <div className="flex items-center mt-6 sm:mt-0">
                   <input
                     id={`liab-include-${l.id}`}


### PR DESCRIPTION
## Summary
- expand liabilities grid to 9 columns
- display a payment column using `computedPayment`
- keep alignment of the new column
- test that a liability's payment amount shows up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685db43289a483239b89bef22006fb36