### PR TITLE
Add Reset Defaults controls

### DIFF
--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -12,6 +12,7 @@ import {
   Cell,
 } from 'recharts'
 import { useFinance } from '../../FinanceContext'
+import { usePersona } from '../../PersonaContext.jsx'
 import CashflowTimelineChart from '../ExpensesGoals/CashflowTimelineChart.jsx'
 import { buildCashflowTimeline } from '../../utils/cashflowTimeline'
 import { getLoanFlowsByYear } from '../../utils/loanHelpers'
@@ -49,6 +50,7 @@ export default function BalanceSheetTab() {
     strategy,
     setStrategy,
   } = useFinance()
+  const { currentData } = usePersona()
 
   const [expandedAssets, setExpandedAssets] = useState({})
   const [expandedLiabilities, setExpandedLiabilities] = useState({})
@@ -175,6 +177,41 @@ export default function BalanceSheetTab() {
     setAssetsList([...assetsList, createAsset()])
   const addLiability = () =>
     setLiabilitiesList([...liabilitiesList, createLiability()])
+
+  const resetDefaults = () => {
+    const now = new Date().getFullYear()
+    if (currentData?.assetsList?.length) {
+      const list = currentData.assetsList.map(a => ({
+        id: crypto.randomUUID(),
+        name: a.name,
+        amount: a.amount ?? a.value ?? 0,
+        type: a.type ?? '',
+        expectedReturn:
+          a.returnAssumptionPct ?? a.expectedReturn ?? a.return ?? 0,
+        volatility: a.volatilityPct ?? a.volatility ?? 0,
+        horizonYears: a.horizonYears ?? 0,
+        purchaseYear: now,
+        saleYear: null,
+        principal: a.principal ?? a.amount ?? a.value ?? 0,
+      }))
+      setAssetsList(list)
+    }
+    if (currentData?.liabilitiesList?.length) {
+      const list = currentData.liabilitiesList.map(l => ({
+        id: crypto.randomUUID(),
+        name: l.name,
+        principal: l.principal ?? 0,
+        interestRate: l.ratePct ?? l.interestRate ?? 0,
+        termYears: l.termYears ?? Math.ceil((l.termMonths || 0) / 12),
+        paymentsPerYear: l.paymentsPerYear ?? 12,
+        extraPayment: l.extraPayment ?? 0,
+        startYear: l.startYear ?? now,
+        endYear: l.endYear ?? null,
+        include: l.include !== false,
+      }))
+      setLiabilitiesList(list)
+    }
+  }
 
   const validateAsset = (asset, idx, list) => {
     if (
@@ -683,6 +720,15 @@ export default function BalanceSheetTab() {
           locale={settings.locale}
           currency={settings.currency}
         />
+        <div className="text-right mt-2">
+          <button
+            onClick={resetDefaults}
+            className="border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+            aria-label="Reset balance sheet to defaults"
+          >
+            Reset Defaults
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/src/tabs/PreferencesTab.jsx
+++ b/src/tabs/PreferencesTab.jsx
@@ -1,6 +1,7 @@
 // src/PreferencesTab.jsx
 import React, { useState, useEffect } from 'react'
 import { useFinance } from '../FinanceContext'
+import { usePersona } from '../PersonaContext.jsx'
 import sanitize from '../utils/sanitize'
 
 function safeParse(str, fallback) {
@@ -23,7 +24,9 @@ export default function PreferencesTab() {
     setIncludeGoalsPV,
     includeLiabilitiesNPV,
     setIncludeLiabilitiesNPV,
+    profile,
   } = useFinance()
+  const { currentData } = usePersona()
   const [form, setForm] = useState(settings)
 
   // Whenever persisted settings change, reset the form
@@ -37,6 +40,39 @@ export default function PreferencesTab() {
     const updated = { ...form, [field]: clean }
     setForm(updated)
     updateSettings(updated)
+  }
+
+  const resetDefaults = () => {
+    const base = {
+      startYear: new Date().getFullYear(),
+      projectionYears: profile.lifeExpectancy - profile.age,
+      chartView: 'nominal',
+      discountRate: 0,
+      inflationRate: 5,
+      expectedReturn: 8,
+      currency: '',
+      locale: 'en-KE',
+      apiEndpoint: '',
+      discretionaryCutThreshold: 0,
+      survivalThresholdMonths: 0,
+      bufferPct: 0,
+      retirementAge: 65,
+      riskCapacityScore: 0,
+      riskWillingnessScore: 0,
+      liquidityBucketDays: 0,
+      taxBrackets: [],
+      pensionContributionReliefPct: 0,
+    }
+    const persona = currentData?.settings || {}
+    const merged = { ...base, ...persona }
+    setForm(merged)
+    updateSettings(merged)
+    setIncludeMediumPV(
+      currentData?.includeMediumPV ?? true
+    )
+    setIncludeLowPV(currentData?.includeLowPV ?? true)
+    setIncludeGoalsPV(currentData?.includeGoalsPV ?? false)
+    setIncludeLiabilitiesNPV(currentData?.includeLiabilitiesNPV ?? false)
   }
 
   return (
@@ -321,6 +357,16 @@ export default function PreferencesTab() {
             title="API endpoint"
           />
         </label>
+      </div>
+
+      <div className="text-right">
+        <button
+          onClick={resetDefaults}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Reset settings to defaults"
+        >
+          Reset Defaults
+        </button>
       </div>
 
       <div className="text-right text-sm text-slate-500 italic">


### PR DESCRIPTION
## Summary
- add persona-aware Reset Defaults button on Preferences
- add persona-aware Reset Defaults button on Balance Sheet

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686116e454d48323beb56ed6b83f00f7