### PR TITLE
Add balance entry persistence tests

### DIFF
--- a/src/__tests__/balanceEntry.persistence.test.js
+++ b/src/__tests__/balanceEntry.persistence.test.js
@@ -1,0 +1,77 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function Controls() {
+  const { assetsList, setAssetsList } = useFinance()
+  const asset = assetsList[0]
+  return (
+    <div>
+      <button
+        onClick={() =>
+          setAssetsList([{ ...asset, purchaseYear: 2020 }])
+        }
+        data-testid="set-purchase"
+      />
+      <button
+        onClick={() => setAssetsList([{ ...asset, saleYear: 2030 }])}
+        data-testid="set-sale"
+      />
+      <button
+        onClick={() => setAssetsList([{ ...asset, principal: 12345 }])}
+        data-testid="set-principal"
+      />
+    </div>
+  )
+}
+
+function Values() {
+  const { assetsList } = useFinance()
+  const asset = assetsList[0]
+  return (
+    <>
+      <div data-testid="purchase-year">{asset.purchaseYear}</div>
+      <div data-testid="sale-year">{asset.saleYear}</div>
+      <div data-testid="principal">{asset.principal}</div>
+    </>
+  )
+}
+
+test('asset fields persist to localStorage and restore on reload', () => {
+  localStorage.setItem('currentPersonaId', 'hadi')
+  const { unmount } = render(
+    <FinanceProvider>
+      <Controls />
+      <Values />
+    </FinanceProvider>
+  )
+
+  fireEvent.click(screen.getByTestId('set-purchase'))
+  fireEvent.click(screen.getByTestId('set-sale'))
+  fireEvent.click(screen.getByTestId('set-principal'))
+
+  const stored = JSON.parse(localStorage.getItem('assetsList-hadi'))[0]
+  expect(stored.purchaseYear).toBe(2020)
+  expect(stored.saleYear).toBe(2030)
+  expect(stored.principal).toBe(12345)
+
+  unmount()
+
+  render(
+    <FinanceProvider>
+      <Values />
+    </FinanceProvider>
+  )
+
+  expect(screen.getByTestId('purchase-year').textContent).toBe('2020')
+  expect(screen.getByTestId('sale-year').textContent).toBe('2030')
+  expect(screen.getByTestId('principal').textContent).toBe('12345')
+})

--- a/src/__tests__/balanceSheet.integration.test.js
+++ b/src/__tests__/balanceSheet.integration.test.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import BalanceSheetTab from '../components/BalanceSheet/BalanceSheetTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function Display() {
+  const { assetsList } = useFinance()
+  const asset = assetsList[0]
+  return <div data-testid="py-val">{asset.purchaseYear}</div>
+}
+
+test('purchaseYear input updates context', () => {
+  localStorage.setItem('currentPersonaId', 'hadi')
+  const { container } = render(
+    <FinanceProvider>
+      <BalanceSheetTab />
+      <Display />
+    </FinanceProvider>
+  )
+
+  // Expand first asset details
+  const toggle = container.querySelector('button[aria-expanded]')
+  if (toggle) fireEvent.click(toggle)
+  const input = screen.getAllByLabelText('Purchase year')[0]
+  fireEvent.change(input, { target: { value: '2010' } })
+  expect(screen.getByTestId('py-val').textContent).toBe('2010')
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,12 @@ export interface Asset {
   expectedReturn?: number
   volatility?: number
   horizonYears?: number
+  /** year asset was purchased */
+  purchaseYear?: number
+  /** year asset will be sold */
+  saleYear?: number | null
+  /** original principal amount */
+  principal?: number
   return?: number
 }
 


### PR DESCRIPTION
## Summary
- add purchase year, sale year and principal fields to `Asset` type
- test that the balance entry fields persist to storage and reload correctly
- integration test for purchaseYear field in `BalanceSheetTab`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68612875671883239fbb9b04da35c204