### PR TITLE
Fix infinite state loops

### DIFF
--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -122,6 +122,7 @@ export default function BalanceSheetTab() {
       if (idx === -1) {
         return [...prev, { id: 'pv-income', name: 'PV of Lifetime Income', amount: incomePV }]
       }
+      if (prev[idx].amount === incomePV) return prev
       const updated = [...prev]
       updated[idx] = { ...updated[idx], amount: incomePV }
       return updated
@@ -135,6 +136,7 @@ export default function BalanceSheetTab() {
       if (idx === -1) {
         return [...prev, { id: 'pv-expenses', name: 'PV of Lifetime Expenses', amount: expensesPV }]
       }
+      if (prev[idx].amount === expensesPV) return prev
       const updated = [...prev]
       updated[idx] = { ...updated[idx], amount: expensesPV }
       return updated


### PR DESCRIPTION
## Summary
- prevent BalanceSheet tab from redundantly updating PV assets

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861556f2cd08323a3a134688e6efaab