### PR TITLE
Implement configurable risk scoring

### DIFF
--- a/src/__tests__/personaSwitch.test.js
+++ b/src/__tests__/personaSwitch.test.js
@@ -19,8 +19,10 @@ test('switching personas updates profile and income tabs', async () => {
   // switch to Amina via dropdown
   fireEvent.change(screen.getByLabelText(/Persona/i), { target: { value: 'amina' } })
 
-  // profile tab shows new name
-  await screen.findByText(/Amina Okoth/i)
+  // profile tab shows new first name in form
+  await waitFor(() => {
+    expect(screen.getByDisplayValue(/Amina/)).toBeInTheDocument()
+  })
   await waitFor(() => expect(localStorage.getItem('currentPersonaId')).toBe('amina'))
 
   // open Income tab so FinanceProvider loads income data

--- a/src/__tests__/riskUtils.test.js
+++ b/src/__tests__/riskUtils.test.js
@@ -1,0 +1,23 @@
+/* global test, expect */
+import { calculateRiskScore, deriveCategory } from '../utils/riskUtils'
+
+test('calculates score and category from profile', () => {
+  const profile = {
+    birthDate: '1990-01-01',
+    annualIncome: 500000,
+    netWorth: 300000,
+    yearsInvesting: 5,
+    employmentStatus: 'Employed',
+    emergencyFundMonths: 6,
+    surveyScore: 40,
+  }
+  const score = calculateRiskScore(profile)
+  expect(score).toBe(41)
+  expect(deriveCategory(score)).toBe('balanced')
+})
+
+test('deriveCategory boundaries', () => {
+  expect(deriveCategory(30)).toBe('conservative')
+  expect(deriveCategory(50)).toBe('balanced')
+  expect(deriveCategory(80)).toBe('growth')
+})

--- a/src/config/riskConfig.js
+++ b/src/config/riskConfig.js
@@ -1,0 +1,15 @@
+export const riskWeights = {
+  age: 0.15,
+  annualIncome: 0.20,
+  netWorth: 0.20,
+  investingExperience: 0.15,
+  employmentStatus: 0.10,
+  liquidityNeeds: 0.10,
+  riskToleranceSurvey: 0.10,
+};
+
+export const riskThresholds = {
+  conservative: { max: 30 },
+  balanced: { min: 31, max: 70 },
+  growth: { min: 71 },
+};

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -1,15 +1,59 @@
-export function calculateRiskScore({ age = 0, annualIncome = 0, liquidNetWorth = 0, employmentStatus = '', ...profile }) {
-  // Basic placeholder weights. In a real app these would be more complex
-  let score = 0
-  if (typeof age === 'number') score += age < 35 ? 10 : age < 50 ? 20 : 30
-  if (typeof annualIncome === 'number') score += annualIncome > 100000 ? 30 : annualIncome > 50000 ? 20 : 10
-  if (typeof liquidNetWorth === 'number') score += liquidNetWorth > 100000 ? 30 : liquidNetWorth > 50000 ? 20 : 10
-  if (employmentStatus === 'Employed') score += 10
-  return Math.min(Math.max(score, 0), 100)
+import { riskWeights, riskThresholds } from '../config/riskConfig';
+
+function calculateAge(birthDate) {
+  if (!birthDate) return 0;
+  const dob = new Date(birthDate);
+  const diff = Date.now() - dob.getTime();
+  const ageDt = new Date(diff);
+  return Math.abs(ageDt.getUTCFullYear() - 1970);
+}
+
+function normalizeAge(birthDate) {
+  const age = calculateAge(birthDate);
+  return Math.max(0, Math.min((age / 100) * 100, 100));
+}
+
+function normalizeIncome(annualIncome) {
+  return Math.max(0, Math.min((annualIncome / 1_000_000) * 100, 100));
+}
+
+function normalizeNetWorth(netWorth) {
+  return Math.max(0, Math.min((netWorth / 5_000_000) * 100, 100));
+}
+
+function normalizeExperience(years) {
+  return Math.max(0, Math.min((years / 30) * 100, 100));
+}
+
+function normalizeEmployment(status) {
+  const mapping = { Retired: 0, Student: 20, 'Self-Employed': 50, Employed: 100 };
+  return mapping[status] ?? 50;
+}
+
+function normalizeLiquidity(needs) {
+  return Math.max(0, Math.min((needs / 12) * 100, 100));
+}
+
+function normalizeSurveyScore(rawScore) {
+  return Math.max(0, Math.min(((rawScore - 10) / 40) * 100, 100));
+}
+
+export function calculateRiskScore(profile = {}) {
+  const scores = {
+    age: normalizeAge(profile.birthDate) * riskWeights.age,
+    annualIncome: normalizeIncome(profile.annualIncome) * riskWeights.annualIncome,
+    netWorth: normalizeNetWorth(profile.netWorth) * riskWeights.netWorth,
+    investingExperience: normalizeExperience(profile.yearsInvesting) * riskWeights.investingExperience,
+    employmentStatus: normalizeEmployment(profile.employmentStatus) * riskWeights.employmentStatus,
+    liquidityNeeds: normalizeLiquidity(profile.emergencyFundMonths) * riskWeights.liquidityNeeds,
+    riskToleranceSurvey: normalizeSurveyScore(profile.surveyScore) * riskWeights.riskToleranceSurvey,
+  };
+  const total = Object.values(scores).reduce((sum, val) => sum + val, 0);
+  return Math.round(Math.max(0, Math.min(total, 100)));
 }
 
 export function deriveCategory(score) {
-  if (score <= 30) return 'conservative'
-  if (score <= 70) return 'balanced'
-  return 'growth'
+  if (score <= riskThresholds.conservative.max) return 'conservative';
+  if (score <= riskThresholds.balanced.max) return 'balanced';
+  return 'growth';
 }


### PR DESCRIPTION
## Summary
- add CFA-aligned risk weights and thresholds
- overhaul `riskUtils` to use normalization functions and config
- use new scoring function in `FinanceContext`
- add unit tests for `riskUtils`
- map persona profiles to new first/last name fields
- verify profile form prepopulates on persona switch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864dfdeedc88323bee131c766de4c1a