### PR TITLE
Remove obsolete risk score configuration

### DIFF
--- a/src/__tests__/riskScoreConfig.test.js
+++ b/src/__tests__/riskScoreConfig.test.js
@@ -1,7 +1,0 @@
-/* global test, expect */
-import { riskScoreMap } from '../riskScoreConfig'
-
-test('riskScoreMap exposes expected categories', () => {
-  const keys = Object.keys(riskScoreMap).sort()
-  expect(keys).toEqual(['goal', 'horizon', 'knowledge', 'response'].sort())
-})

--- a/src/riskScoreConfig.js
+++ b/src/riskScoreConfig.js
@@ -1,6 +1,0 @@
-export const riskScoreMap = {
-  knowledge: { None: 1, Basic: 2, Moderate: 3, Advanced: 4 },
-  response: { Sell: 1, Wait: 3, BuyMore: 5 },
-  horizon: { '<3 years': 1, '3–7 years': 3, '>7 years': 5 },
-  goal: { Preservation: 1, Income: 3, Growth: 5 }
-}

--- a/src/riskScoreMap.js
+++ b/src/riskScoreMap.js
@@ -1,5 +1,0 @@
-export const riskScoreMap = {
-  conservative: { min: 0, max: 30 },
-  balanced: { min: 31, max: 70 },
-  growth: { min: 71, max: 100 }
-}


### PR DESCRIPTION
## Summary
- delete riskScoreConfig.js and riskScoreMap.js which were no longer referenced
- drop related riskScoreConfig test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864f7eb50d883239d427440015d520d