### PR TITLE
Align strategy thresholds with risk config

### DIFF
--- a/src/__tests__/financeContext.strategy.test.js
+++ b/src/__tests__/financeContext.strategy.test.js
@@ -17,7 +17,7 @@ function StrategyDisplay() {
 
 test('strategy is derived when risk score loads from storage', async () => {
   localStorage.setItem('currentPersonaId', 'hadi')
-  localStorage.setItem('riskScore-hadi', '7')
+  localStorage.setItem('riskScore-hadi', '31')
   localStorage.setItem('profile-hadi', JSON.stringify({ investmentHorizon: '3–7 years' }))
   render(
     <FinanceProvider>

--- a/src/__tests__/strategyUtils.test.js
+++ b/src/__tests__/strategyUtils.test.js
@@ -1,18 +1,18 @@
 import { deriveStrategy } from '../utils/strategyUtils'
 
-test('risk score boundary at 6 is Conservative', () => {
-  expect(deriveStrategy(6, '3–7 years')).toBe('Conservative')
+test('risk score boundary at 30 is Conservative', () => {
+  expect(deriveStrategy(30, '3–7 years')).toBe('Conservative')
 })
 
-test('risk score 7 yields Balanced', () => {
-  expect(deriveStrategy(7, '3–7 years')).toBe('Balanced')
+test('risk score 31 yields Balanced', () => {
+  expect(deriveStrategy(31, '3–7 years')).toBe('Balanced')
 })
 
-test('risk score 12 yields Balanced', () => {
-  expect(deriveStrategy(12, '3–7 years')).toBe('Balanced')
+test('risk score 70 yields Balanced', () => {
+  expect(deriveStrategy(70, '3–7 years')).toBe('Balanced')
 })
 
-test('risk score above 12 yields Growth', () => {
-  expect(deriveStrategy(13, '3–7 years')).toBe('Growth')
+test('risk score above 70 yields Growth', () => {
+  expect(deriveStrategy(71, '3–7 years')).toBe('Growth')
 })
 

--- a/src/utils/strategyUtils.js
+++ b/src/utils/strategyUtils.js
@@ -1,10 +1,12 @@
 // src/utils/strategyUtils.js
 // Utility to derive investment strategy based on risk score and horizon.
 
+import { riskThresholds } from '../config/riskConfig'
+
 export function deriveStrategy(riskScore = 0, horizon = '') {
   let base
-  if (riskScore <= 6) base = 'Conservative'
-  else if (riskScore <= 12) base = 'Balanced'
+  if (riskScore <= riskThresholds.conservative.max) base = 'Conservative'
+  else if (riskScore <= riskThresholds.balanced.max) base = 'Balanced'
   else base = 'Growth'
 
   if (horizon === '<3 years') return 'Conservative'


### PR DESCRIPTION
## Summary
- follow risk thresholds in strategy utils
- update unit tests for new ranges
- confirm FinanceContext derives strategy from stored score

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864fb85353083239333fd282d366bdc