### PR TITLE
Update risk scoring inputs

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -50,6 +50,7 @@ const defaultProfile = {
   taxId: '',
   employmentStatus: '',
   employerName: '',
+  birthDate: '',
   age: 30,
   maritalStatus: '', // FIXME: unused - pending integration
   numDependents: 0, // FIXME: unused - pending integration
@@ -62,6 +63,7 @@ const defaultProfile = {
   idNumber: '', // FIXME: unused - pending integration
   taxResidence: '', // FIXME: unused - pending integration
   annualIncome: 0,
+  netWorth: 0,
   liquidNetWorth: 0,
   sourceOfFunds: '', // FIXME: unused - pending integration
   behaviouralProfile: {}, // FIXME: unused - pending integration
@@ -91,6 +93,15 @@ function mapPersonaProfile(seed = {}) {
   }
   if (seed.taxResidence && !seed.taxCountry) {
     out.taxCountry = seed.taxResidence
+  }
+  if (seed.birthDate && typeof seed.age !== 'number') {
+    const dob = new Date(seed.birthDate)
+    const diff = Date.now() - dob.getTime()
+    const ageDt = new Date(diff)
+    out.age = Math.abs(ageDt.getUTCFullYear() - 1970)
+  }
+  if (typeof seed.netWorth === 'number' && typeof seed.liquidNetWorth !== 'number') {
+    out.liquidNetWorth = seed.netWorth
   }
   return out
 }

--- a/src/__tests__/riskUtils.test.js
+++ b/src/__tests__/riskUtils.test.js
@@ -16,6 +16,25 @@ test('calculates score and category from profile', () => {
   expect(deriveCategory(score)).toBe('balanced')
 })
 
+test('age and liquid net worth influence score', () => {
+  const base = {
+    age: 30,
+    annualIncome: 500000,
+    liquidNetWorth: 300000,
+    yearsInvesting: 5,
+    employmentStatus: 'Employed',
+    emergencyFundMonths: 6,
+    surveyScore: 40,
+  }
+  const younger = { ...base, age: 20 }
+  const older = { ...base, age: 60 }
+  const lowerNW = { ...base, liquidNetWorth: 100000 }
+  const higherNW = { ...base, liquidNetWorth: 1000000 }
+
+  expect(calculateRiskScore(older)).toBeGreaterThan(calculateRiskScore(younger))
+  expect(calculateRiskScore(higherNW)).toBeGreaterThan(calculateRiskScore(lowerNW))
+})
+
 test('deriveCategory boundaries', () => {
   expect(deriveCategory(30)).toBe('conservative')
   expect(deriveCategory(50)).toBe('balanced')

--- a/src/components/Profile/ProfileTab.jsx
+++ b/src/components/Profile/ProfileTab.jsx
@@ -40,6 +40,17 @@ export default function ProfileTab() {
       updated.lifeExpectancy = updated.age + 1
     } else if (field === 'age' && updated.lifeExpectancy <= value) {
       updated.lifeExpectancy = value + 1
+    } else if (field === 'birthDate') {
+      const dob = new Date(value)
+      if (!isNaN(dob)) {
+        const diff = Date.now() - dob.getTime()
+        const ageDt = new Date(diff)
+        const years = Math.abs(ageDt.getUTCFullYear() - 1970)
+        updated.age = years
+        if (updated.lifeExpectancy <= years) {
+          updated.lifeExpectancy = years + 1
+        }
+      }
     }
 
     setForm(updated)
@@ -79,6 +90,7 @@ export default function ProfileTab() {
             ['Tax ID', 'taxId', 'text'],
             ['Employment Status', 'employmentStatus', 'text'],
             ['Employer Name', 'employerName', 'text'],
+            ['Birth Date', 'birthDate', 'date'],
             ['Age', 'age', 'number'],
             ['Life Expectancy', 'lifeExpectancy', 'number'],
             ['Dependents', 'numDependents', 'number'],

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -8,8 +8,14 @@ function calculateAge(birthDate) {
   return Math.abs(ageDt.getUTCFullYear() - 1970);
 }
 
-function normalizeAge(birthDate) {
-  const age = calculateAge(birthDate);
+function extractAge(profile) {
+  if (typeof profile.age === 'number' && !Number.isNaN(profile.age)) {
+    return profile.age;
+  }
+  return calculateAge(profile.birthDate);
+}
+
+function normalizeAgeValue(age) {
   return Math.max(0, Math.min((age / 100) * 100, 100));
 }
 
@@ -19,6 +25,19 @@ function normalizeIncome(annualIncome) {
 
 function normalizeNetWorth(netWorth) {
   return Math.max(0, Math.min((netWorth / 5_000_000) * 100, 100));
+}
+
+function extractNetWorth(profile) {
+  if (typeof profile.netWorth === 'number' && !Number.isNaN(profile.netWorth)) {
+    return profile.netWorth;
+  }
+  if (
+    typeof profile.liquidNetWorth === 'number' &&
+    !Number.isNaN(profile.liquidNetWorth)
+  ) {
+    return profile.liquidNetWorth;
+  }
+  return 0;
 }
 
 function normalizeExperience(years) {
@@ -39,10 +58,12 @@ function normalizeSurveyScore(rawScore) {
 }
 
 export function calculateRiskScore(profile = {}) {
+  const age = extractAge(profile);
+  const netWorth = extractNetWorth(profile);
   const scores = {
-    age: normalizeAge(profile.birthDate) * riskWeights.age,
+    age: normalizeAgeValue(age) * riskWeights.age,
     annualIncome: normalizeIncome(profile.annualIncome) * riskWeights.annualIncome,
-    netWorth: normalizeNetWorth(profile.netWorth) * riskWeights.netWorth,
+    netWorth: normalizeNetWorth(netWorth) * riskWeights.netWorth,
     investingExperience: normalizeExperience(profile.yearsInvesting) * riskWeights.investingExperience,
     employmentStatus: normalizeEmployment(profile.employmentStatus) * riskWeights.employmentStatus,
     liquidityNeeds: normalizeLiquidity(profile.emergencyFundMonths) * riskWeights.liquidityNeeds,


### PR DESCRIPTION
## Summary
- support `age` or `birthDate` and `netWorth` or `liquidNetWorth` in `calculateRiskScore`
- include optional fields in profile defaults and seed mapping
- record birth date in the profile UI
- test the effect of age and liquid net worth on the risk score

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68656e330f848323b1adbdaa0bdf9e86