### PR TITLE
Enhance risk scoring logic with questionnaire data

### DIFF
--- a/src/__tests__/riskUtils.test.js
+++ b/src/__tests__/riskUtils.test.js
@@ -10,9 +10,13 @@ test('calculates score and category from profile', () => {
     employmentStatus: 'Employed',
     emergencyFundMonths: 6,
     surveyScore: 40,
+    investmentKnowledge: 'Moderate',
+    lossResponse: 'Wait',
+    investmentHorizon: '>7 years',
+    investmentGoal: 'Growth',
   }
   const score = calculateRiskScore(profile)
-  expect(score).toBe(41)
+  expect(score).toBe(53)
   expect(deriveCategory(score)).toBe('balanced')
 })
 
@@ -25,6 +29,10 @@ test('age and liquid net worth influence score', () => {
     employmentStatus: 'Employed',
     emergencyFundMonths: 6,
     surveyScore: 40,
+    investmentKnowledge: 'Moderate',
+    lossResponse: 'Wait',
+    investmentHorizon: '>7 years',
+    investmentGoal: 'Growth',
   }
   const younger = { ...base, age: 20 }
   const older = { ...base, age: 60 }
@@ -33,6 +41,26 @@ test('age and liquid net worth influence score', () => {
 
   expect(calculateRiskScore(older)).toBeGreaterThan(calculateRiskScore(younger))
   expect(calculateRiskScore(higherNW)).toBeGreaterThan(calculateRiskScore(lowerNW))
+})
+
+test('questionnaire factors influence score', () => {
+  const base = {
+    age: 30,
+    annualIncome: 500000,
+    liquidNetWorth: 300000,
+    yearsInvesting: 5,
+    employmentStatus: 'Employed',
+    emergencyFundMonths: 6,
+    surveyScore: 40,
+    investmentKnowledge: 'Moderate',
+    lossResponse: 'Wait',
+    investmentHorizon: '>7 years',
+    investmentGoal: 'Growth',
+  }
+  const lowKnowledge = { ...base, investmentKnowledge: 'None' }
+  const shortHorizon = { ...base, investmentHorizon: '<3 years' }
+  expect(calculateRiskScore(lowKnowledge)).toBeLessThan(calculateRiskScore(base))
+  expect(calculateRiskScore(shortHorizon)).toBeLessThan(calculateRiskScore(base))
 })
 
 test('deriveCategory boundaries', () => {

--- a/src/config/riskConfig.js
+++ b/src/config/riskConfig.js
@@ -1,11 +1,15 @@
 export const riskWeights = {
-  age: 0.15,
-  annualIncome: 0.20,
-  netWorth: 0.20,
-  investingExperience: 0.15,
-  employmentStatus: 0.10,
-  liquidityNeeds: 0.10,
+  age: 0.10,
+  annualIncome: 0.15,
+  netWorth: 0.15,
+  investingExperience: 0.10,
+  employmentStatus: 0.05,
+  liquidityNeeds: 0.05,
   riskToleranceSurvey: 0.10,
+  investmentKnowledge: 0.10,
+  lossResponse: 0.05,
+  investmentHorizon: 0.10,
+  investmentGoal: 0.05,
 };
 
 export const riskThresholds = {

--- a/src/config/riskScoreConfig.js
+++ b/src/config/riskScoreConfig.js
@@ -1,0 +1,33 @@
+export const employmentStatusScores = {
+  Retired: 0,
+  Student: 20,
+  'Self-Employed': 50,
+  'Part-Time': 70,
+  Employed: 100,
+  'Full-Time': 100
+};
+
+export const investmentKnowledgeScores = {
+  None: 0,
+  Basic: 33,
+  Moderate: 66,
+  Advanced: 100
+};
+
+export const lossResponseScores = {
+  Sell: 0,
+  Wait: 50,
+  BuyMore: 100
+};
+
+export const investmentHorizonScores = {
+  '<3 years': 0,
+  '3–7 years': 50,
+  '>7 years': 100
+};
+
+export const investmentGoalScores = {
+  Preservation: 0,
+  Income: 50,
+  Growth: 100
+};

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -1,4 +1,11 @@
 import { riskWeights, riskThresholds } from '../config/riskConfig';
+import {
+  employmentStatusScores,
+  investmentKnowledgeScores,
+  lossResponseScores,
+  investmentHorizonScores,
+  investmentGoalScores,
+} from '../config/riskScoreConfig.js';
 
 function calculateAge(birthDate) {
   if (!birthDate) return 0;
@@ -45,8 +52,23 @@ function normalizeExperience(years) {
 }
 
 function normalizeEmployment(status) {
-  const mapping = { Retired: 0, Student: 20, 'Self-Employed': 50, Employed: 100 };
-  return mapping[status] ?? 50;
+  return employmentStatusScores[status] ?? 50;
+}
+
+function normalizeKnowledge(level) {
+  return investmentKnowledgeScores[level] ?? 50;
+}
+
+function normalizeLossResponse(response) {
+  return lossResponseScores[response] ?? 50;
+}
+
+function normalizeHorizon(horizon) {
+  return investmentHorizonScores[horizon] ?? 50;
+}
+
+function normalizeGoal(goal) {
+  return investmentGoalScores[goal] ?? 50;
 }
 
 function normalizeLiquidity(needs) {
@@ -68,6 +90,10 @@ export function calculateRiskScore(profile = {}) {
     employmentStatus: normalizeEmployment(profile.employmentStatus) * riskWeights.employmentStatus,
     liquidityNeeds: normalizeLiquidity(profile.emergencyFundMonths) * riskWeights.liquidityNeeds,
     riskToleranceSurvey: normalizeSurveyScore(profile.surveyScore) * riskWeights.riskToleranceSurvey,
+    investmentKnowledge: normalizeKnowledge(profile.investmentKnowledge) * riskWeights.investmentKnowledge,
+    lossResponse: normalizeLossResponse(profile.lossResponse) * riskWeights.lossResponse,
+    investmentHorizon: normalizeHorizon(profile.investmentHorizon) * riskWeights.investmentHorizon,
+    investmentGoal: normalizeGoal(profile.investmentGoal) * riskWeights.investmentGoal,
   };
   const total = Object.values(scores).reduce((sum, val) => sum + val, 0);
   return Math.round(Math.max(0, Math.min(total, 100)));


### PR DESCRIPTION
## Summary
- add `riskScoreConfig.js` defining score mappings
- expand `riskConfig.js` weights to include questionnaire factors
- include questionnaire normalization in `riskUtils`
- adjust risk score tests for new fields and add extra coverage

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68656fda1ff483238d0899a8681a679a