### PR TITLE
Handle legacy risk score migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ The app derives a default strategy from your profile. A `riskScore` is computed 
 
 The chosen strategy is stored in `FinanceContext` and persisted in local storage. You may pick a different option under the **Balance Sheet** tab which overrides the automatic choice and is saved for later visits.
 
+### Risk Score Migration
+
+Earlier releases stored risk scores on a 0–12 scale. On startup the app checks
+`riskScore` in local storage and treats values of 12 or less as legacy. If a
+profile is available the score is recomputed using the new algorithm; otherwise
+the old value is scaled to the 0–100 range and written back.
+
 ## Insurance Calculator
 
 The **Insurance** tab provides an estimate of emergency savings and life cover

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -1147,9 +1147,20 @@ export function FinanceProvider({ children }) {
     }
 
     if (rs) {
-      setRiskScore(+rs)
+      const num = +rs
+      if (num <= 12) {
+        const score = loadedProfile
+          ? calculateRiskScore(loadedProfile)
+          : Math.round((num / 12) * 100)
+        setRiskScore(score)
+        storage.set('riskScore', score)
+      } else {
+        setRiskScore(num)
+      }
     } else if (loadedProfile) {
-      setRiskScore(calculateRiskScore(loadedProfile))
+      const score = calculateRiskScore(loadedProfile)
+      setRiskScore(score)
+      storage.set('riskScore', score)
     }
 
     const sSet = storage.get('settings')

--- a/src/__tests__/financeContext.strategy.test.js
+++ b/src/__tests__/financeContext.strategy.test.js
@@ -15,6 +15,11 @@ function StrategyDisplay() {
   return <div data-testid="strategy">{strategy}</div>
 }
 
+function ScoreDisplay() {
+  const { riskScore } = useFinance()
+  return <div data-testid="score">{riskScore}</div>
+}
+
 test('strategy is derived when risk score loads from storage', async () => {
   localStorage.setItem('currentPersonaId', 'hadi')
   localStorage.setItem('riskScore-hadi', '31')
@@ -40,4 +45,33 @@ test('existing strategy is preserved', async () => {
   )
   const out = await screen.findByTestId('strategy')
   expect(out.textContent).toBe('Growth')
+})
+
+test('legacy risk score is migrated', async () => {
+  localStorage.setItem('currentPersonaId', 'hadi')
+  localStorage.setItem('riskScore-hadi', '8')
+  localStorage.setItem(
+    'profile-hadi',
+    JSON.stringify({
+      birthDate: '1990-01-01',
+      annualIncome: 500000,
+      netWorth: 300000,
+      yearsInvesting: 5,
+      employmentStatus: 'Employed',
+      emergencyFundMonths: 6,
+      surveyScore: 40,
+      investmentKnowledge: 'Moderate',
+      lossResponse: 'Wait',
+      investmentHorizon: '>7 years',
+      investmentGoal: 'Growth',
+    })
+  )
+  render(
+    <FinanceProvider>
+      <ScoreDisplay />
+    </FinanceProvider>
+  )
+  const out = await screen.findByTestId('score')
+  expect(Number(out.textContent)).toBeGreaterThan(12)
+  expect(localStorage.getItem('riskScore-hadi')).toBe(out.textContent)
 })


### PR DESCRIPTION
## Summary
- migrate legacy risk scores at startup
- document migration logic
- add regression test for migration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865747a854083238303c8ed4120742e