### PR TITLE
Implement week 1 and 2 profile setup

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -24,6 +24,7 @@ import { projectPensionGrowth } from './utils/pensionProjection.js'
 import storage from './utils/storage'
 import hadiSeed from './data/hadiSeed.json'
 import { defaultIncomeSources } from './components/Income/defaults.js'
+import { readVersions } from './utils/versionHistory'
 
 const DEFAULT_CURRENCY_MAP = {
   Kenyan: 'KES',
@@ -575,6 +576,19 @@ export function FinanceProvider({ children }) {
       updateProfile(mapPersonaProfile(currentData.profile))
     }
   }, [currentData, updateProfile])
+
+  const revertProfile = useCallback(index => {
+    const versions = readVersions(storage)
+    const snap =
+      versions.length === 0
+        ? null
+        : typeof index === 'number'
+          ? versions[index]
+          : versions[versions.length - 1]
+    if (snap && snap.profile) {
+      updateProfile(snap.profile)
+    }
+  }, [updateProfile])
 
   // Derive default currency when none chosen
   useEffect(() => {
@@ -1383,6 +1397,7 @@ export function FinanceProvider({ children }) {
       profile,       updateProfile,
       clearProfile,
       resetProfile,
+      revertProfile,
       riskScore,
       strategy,     setStrategy,
 

--- a/src/__tests__/profileVersionHistory.test.js
+++ b/src/__tests__/profileVersionHistory.test.js
@@ -1,0 +1,17 @@
+import { addVersion, readVersions, clearVersions } from '../utils/versionHistory';
+import storage from '../utils/storage';
+
+describe('profile version history', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearVersions(storage);
+  });
+
+  test('addVersion stores snapshots', () => {
+    const profile = { firstName: 'Jane' };
+    addVersion(storage, profile);
+    const versions = readVersions(storage);
+    expect(versions).toHaveLength(1);
+    expect(versions[0].profile).toEqual(profile);
+  });
+});

--- a/src/components/Profile/PersonalDetailsStep.jsx
+++ b/src/components/Profile/PersonalDetailsStep.jsx
@@ -5,6 +5,7 @@ import storage from '../../utils/storage'
 import sanitize from '../../utils/sanitize'
 import { record, flush } from '../../utils/auditLog'
 import { profileSchema } from '../../validation/profileSchema.js'
+import { addVersion } from '../../utils/versionHistory'
 
 export default function PersonalDetailsStep({ onNext }) {
   const {
@@ -101,6 +102,7 @@ export default function PersonalDetailsStep({ onNext }) {
                 <select
                   value={form[field]}
                   onChange={e => handleChange(field, e.target.value)}
+                  onBlur={() => addVersion(storage, form)}
                   className="w-full border rounded-md p-2"
                   title={label}
                 >
@@ -120,6 +122,7 @@ export default function PersonalDetailsStep({ onNext }) {
                       type === 'number' ? parseFloat(e.target.value) || 0 : e.target.value
                     )
                   }
+                  onBlur={() => addVersion(storage, form)}
                   className="w-full border rounded-md p-2"
                   title={label}
                 />
@@ -144,6 +147,7 @@ export default function PersonalDetailsStep({ onNext }) {
                 type="number"
                 value={form[field]}
                 onChange={e => handleChange(field, parseFloat(e.target.value) || 0)}
+                onBlur={() => addVersion(storage, form)}
                 className="w-full border rounded-md p-2"
                 title={label}
               />
@@ -158,6 +162,7 @@ export default function PersonalDetailsStep({ onNext }) {
             <textarea
               value={form.sourceOfFunds}
               onChange={e => handleChange('sourceOfFunds', e.target.value)}
+              onBlur={() => addVersion(storage, form)}
               className="w-full border rounded-md p-2"
               rows={3}
               title="Source of funds"
@@ -170,6 +175,7 @@ export default function PersonalDetailsStep({ onNext }) {
               type="text"
               value={form.financialChallenge}
               onChange={e => handleChange('financialChallenge', e.target.value)}
+              onBlur={() => addVersion(storage, form)}
               className="w-full border rounded-md p-2"
               title="Primary Financial Challenge"
             />
@@ -188,6 +194,7 @@ export default function PersonalDetailsStep({ onNext }) {
                     spendingHabits: e.target.value
                   })
                 }
+                onBlur={() => addVersion(storage, form)}
                 className="w-full border rounded-md p-2"
                 title="Spending Habits"
               />
@@ -206,6 +213,7 @@ export default function PersonalDetailsStep({ onNext }) {
                       .filter(Boolean)
                   })
                 }
+                onBlur={() => addVersion(storage, form)}
                 className="w-full border rounded-md p-2"
                 title="Biases"
               />
@@ -221,6 +229,7 @@ export default function PersonalDetailsStep({ onNext }) {
                     financialWorries: e.target.value
                   })
                 }
+                onBlur={() => addVersion(storage, form)}
                 className="w-full border rounded-md p-2"
                 title="Financial Worries"
               />

--- a/src/schemas/profileSchemas.js
+++ b/src/schemas/profileSchemas.js
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const personalInfoSchema = z.object({
+  firstName: z.string().min(1, 'Required'),
+  lastName: z.string().min(1, 'Required'),
+  email: z.string().email('Invalid email'),
+  phone: z.string().min(1, 'Required'),
+  address: z.string().optional().default(''),
+  city: z.string().optional().default(''),
+  country: z.string().optional().default(''),
+  taxCountry: z.string().optional().default(''),
+  taxId: z.string().optional().default(''),
+  employmentStatus: z.string().min(1, 'Required'),
+  employerName: z.string().optional().default(''),
+  birthDate: z.string().min(1, 'Required'),
+  age: z.number().nonnegative().default(30),
+  lifeExpectancy: z.number().positive().default(85),
+  numDependents: z.number().nonnegative().default(0),
+  education: z.string().optional().default('')
+});
+
+export const financialInfoSchema = z.object({
+  annualIncome: z.number().nonnegative().default(0),
+  netWorth: z.number().nonnegative().optional().default(0),
+  liquidNetWorth: z.number().nonnegative().optional().default(0)
+});

--- a/src/utils/versionHistory.js
+++ b/src/utils/versionHistory.js
@@ -1,0 +1,24 @@
+export function readVersions(storage) {
+  try {
+    const raw = storage.get('profile-versions');
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addVersion(storage, profile) {
+  const versions = readVersions(storage);
+  versions.push({ ts: new Date().toISOString(), profile });
+  try {
+    storage.set('profile-versions', JSON.stringify(versions));
+  } catch (err) {
+    console.error('Failed to write version history', err);
+  }
+}
+
+export function clearVersions(storage) {
+  try {
+    storage.remove('profile-versions');
+  } catch {}
+}

--- a/src/validation/profileSchema.js
+++ b/src/validation/profileSchema.js
@@ -1,21 +1,7 @@
 import { z } from 'zod'
+import { personalInfoSchema, financialInfoSchema } from '../schemas/profileSchemas'
 
-export const profileSchema = z.object({
-  firstName: z.string().min(1, 'Required'),
-  lastName: z.string().min(1, 'Required'),
-  email: z.string().email('Invalid email'),
-  phone: z.string().min(1, 'Required'),
-  address: z.string().optional().default(''),
-  city: z.string().optional().default(''),
-  country: z.string().optional().default(''),
-  taxCountry: z.string().optional().default(''),
-  taxId: z.string().optional().default(''),
-  employmentStatus: z.string().min(1, 'Required'),
-  employerName: z.string().optional().default(''),
-  birthDate: z.string().min(1, 'Required'),
-  annualIncome: z.number().nonnegative().default(0),
-  netWorth: z.number().nonnegative().optional().default(0),
-  liquidNetWorth: z.number().nonnegative().optional().default(0),
+export const profileSchema = personalInfoSchema.merge(financialInfoSchema).extend({
   yearsInvesting: z.number().nonnegative().optional().default(0),
   emergencyFundMonths: z.number().nonnegative().optional().default(0),
   riskSurveyAnswers: z


### PR DESCRIPTION
## Summary
- scaffold personal profile schemas
- add profile version history utilities with tests
- update validation to use new schemas
- add revertProfile helper to context
- auto-save profile versions on blur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686636e59cf48323a8dbe26feae3784b