### PR TITLE
Add week 3-5 finance module tests

### DIFF
--- a/src/__tests__/balanceSheet.sync.test.js
+++ b/src/__tests__/balanceSheet.sync.test.js
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import BalanceSheetTab from '../components/BalanceSheet/BalanceSheetTab'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => { localStorage.clear() })
+
+function Controls() {
+  const { assetsList, setAssetsList, liabilitiesList, setLiabilitiesList } = useFinance()
+  const updateAsset = () => {
+    setAssetsList(prev => prev.map((a, i) => i === 0 ? { ...a, amount: 2000 } : a))
+  }
+  const updateLiability = () => {
+    setLiabilitiesList(prev => prev.map((l, i) => i === 0 ? { ...l, amount: 300, principal: 300 } : l))
+  }
+  return (
+    <div>
+      <button data-testid="asset" onClick={updateAsset}>asset</button>
+      <button data-testid="liability" onClick={updateLiability}>liability</button>
+    </div>
+  )
+}
+
+test('net worth updates when registry values change', async () => {
+  const now = new Date().getFullYear()
+  localStorage.setItem('currentPersonaId', 'hadi')
+  localStorage.setItem('profile-hadi', JSON.stringify({ age:30, lifeExpectancy:85, nationality:'Kenyan' }))
+  localStorage.setItem('settings-hadi', JSON.stringify({ startYear: now }))
+  localStorage.setItem('incomeSources-hadi', '[]')
+  localStorage.setItem('expensesList-hadi', '[]')
+  localStorage.setItem('goalsList-hadi', '[]')
+  localStorage.setItem('assetsList-hadi', JSON.stringify([
+    { id:'a1', name:'Cash', amount:1000, type:'Cash', expectedReturn:0, volatility:0, horizonYears:0, purchaseYear: now, saleYear:null, principal:1000 },
+    { id:'pv-income', name:'PV of Lifetime Income', amount:0, type:'Income', expectedReturn:0, volatility:0, horizonYears:0, purchaseYear: now, saleYear:null, principal:0 }
+  ]))
+  localStorage.setItem('liabilitiesList-hadi', JSON.stringify([
+    { id:'l1', name:'Loan', amount:500, principal:500, interestRate:0, termYears:1, paymentsPerYear:12, extraPayment:0, startYear: now, endYear:null, include:true }
+  ]))
+
+  render(
+    <FinanceProvider>
+      <BalanceSheetTab />
+      <Controls />
+    </FinanceProvider>
+  )
+
+  const netNode = await screen.findByTestId('net-worth')
+  expect(netNode.textContent).toBe('KES\u00a0500.00')
+
+  fireEvent.click(screen.getByTestId('asset'))
+  await waitFor(() => expect(netNode.textContent).toBe('KES\u00a01,500.00'))
+
+  fireEvent.click(screen.getByTestId('liability'))
+  await waitFor(() => expect(netNode.textContent).toBe('KES\u00a01,700.00'))
+})

--- a/src/__tests__/crossModule.surplus.test.js
+++ b/src/__tests__/crossModule.surplus.test.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } })
+
+afterEach(() => { localStorage.clear() })
+
+function SurplusControls() {
+  const { incomeSources, setIncomeSources, expensesList, setExpensesList, monthlySurplusNominal } = useFinance()
+  const boostIncome = () => setIncomeSources(prev => prev.map((s,i)=> i===0 ? { ...s, amount: 1500 } : s))
+  const increaseExpense = () => setExpensesList(prev => prev.map((e,i)=> i===0 ? { ...e, amount: 1000 } : e))
+  return (
+    <div>
+      <div data-testid="surplus">{monthlySurplusNominal}</div>
+      <button data-testid="income" onClick={boostIncome}>income</button>
+      <button data-testid="expense" onClick={increaseExpense}>expense</button>
+    </div>
+  )
+}
+
+test('monthly surplus reflects income and expense changes', async () => {
+  const now = new Date().getFullYear()
+  localStorage.setItem('currentPersonaId', 'hadi')
+  localStorage.setItem('profile-hadi', JSON.stringify({ age:30, lifeExpectancy:85, nationality:'Kenyan' }))
+  localStorage.setItem('settings-hadi', JSON.stringify({ startYear: now }))
+  localStorage.setItem('incomeSources-hadi', JSON.stringify([
+    { name:'Job', type:'Salary', amount:1000, frequency:12, growth:0, taxRate:0 }
+  ]))
+  localStorage.setItem('expensesList-hadi', JSON.stringify([
+    { name:'Rent', amount:800, paymentsPerYear:12, startYear: now }
+  ]))
+
+  render(
+    <FinanceProvider>
+      <SurplusControls />
+    </FinanceProvider>
+  )
+
+  const node = await screen.findByTestId('surplus')
+  expect(node.textContent).toBe('200')
+
+  fireEvent.click(screen.getByTestId('income'))
+  await waitFor(() => expect(node.textContent).toBe('700'))
+
+  fireEvent.click(screen.getByTestId('expense'))
+  await waitFor(() => expect(node.textContent).toBe('500'))
+})

--- a/src/__tests__/incomePV.streams.test.js
+++ b/src/__tests__/incomePV.streams.test.js
@@ -1,0 +1,66 @@
+import { calculatePV as calcStreamPV } from '../components/Income/helpers'
+
+function manualPV(amount, freq, growth, discount, periods) {
+  let pv = 0
+  const r = 1 + discount / 100
+  for (let i = 0; i < periods; i++) {
+    const cash = amount * freq * Math.pow(1 + growth / 100, i)
+    pv += cash / Math.pow(r, i + 1)
+  }
+  return pv
+}
+
+test('salary present value calculation', () => {
+  const now = new Date().getFullYear()
+  const stream = {
+    amount: 1000,
+    frequency: 12,
+    growth: 0,
+    taxRate: 20,
+    startYear: now,
+    endYear: now + 2,
+    type: 'Salary'
+  }
+  const pv = calcStreamPV(stream, 5, 5, { birthYear: now - 30 })
+  const expectedGross = manualPV(1000, 12, 0, 5, 3)
+  const expectedNet = expectedGross * 0.8
+  expect(pv.gross).toBeCloseTo(expectedGross, 6)
+  expect(pv.net).toBeCloseTo(expectedNet, 6)
+})
+
+test('bonus present value calculation', () => {
+  const now = new Date().getFullYear()
+  const stream = {
+    amount: 2000,
+    frequency: 1,
+    growth: 0,
+    taxRate: 10,
+    startYear: now + 1,
+    endYear: now + 3,
+    type: 'Bonus'
+  }
+  const pv = calcStreamPV(stream, 5, 5, { birthYear: now - 30 })
+  const expectedImmediate = manualPV(2000, 1, 0, 5, 3)
+  const offset = 1
+  const expectedGross = expectedImmediate / Math.pow(1 + 0.05, offset)
+  const expectedNet = expectedGross * 0.9
+  expect(pv.gross).toBeCloseTo(expectedGross, 6)
+  expect(pv.net).toBeCloseTo(expectedNet, 6)
+})
+
+test('rental income present value with growth', () => {
+  const now = new Date().getFullYear()
+  const stream = {
+    amount: 500,
+    frequency: 12,
+    growth: 3,
+    taxRate: 0,
+    startYear: now,
+    endYear: now + 4,
+    type: 'Rental'
+  }
+  const pv = calcStreamPV(stream, 5, 5, { birthYear: now - 30 })
+  const expectedGross = manualPV(500, 12, 3, 5, 5)
+  expect(pv.gross).toBeCloseTo(expectedGross, 6)
+  expect(pv.net).toBeCloseTo(expectedGross, 6)
+})

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -603,7 +603,10 @@ export default function BalanceSheetTab() {
       </div>
 
       <div className="text-md text-slate-700 italic">
-        Net Worth: <span className="text-2xl font-bold text-amber-800">{formatCurrency(netWorth, settings.locale, settings.currency)}</span>
+        Net Worth: <span
+          className="text-2xl font-bold text-amber-800"
+          data-testid="net-worth"
+        >{formatCurrency(netWorth, settings.locale, settings.currency)}</span>
         {debtAssetRatio > 1 && (
           <span className="block text-red-600 text-sm">Warning: Debt exceeds assets ({(debtAssetRatio * 100).toFixed(1)}%).</span>
         )}


### PR DESCRIPTION
## Summary
- add `net-worth` test id for balance sheet
- unit test PV calculations for salary, bonus and rental streams
- integration test that balance sheet reflects asset/liability changes
- cross module test for income/expense surplus updates

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866392ae4f08323b4862be42885fafa