### PR TITLE
Implement Phase 5 compliance and onboarding tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ import { buildIncomeJSON, buildPlanJSON, submitProfile } from './src/utils/expor
 
 Calling `submitProfile()` sends the generated JSON to the configured endpoint.
 
+### Data Compliance
+
+The submission helper strips personally identifiable information before
+POSTing data. Fields such as email, phone number and address are removed
+so the payload only contains non-sensitive profile attributes. Unit tests
+cover this behavior in `compliance.test.js`.
+
 ## Income Views
 
 Above the income chart you'll find **Nominal** and **Discounted** buttons used to toggle between raw projections and present value figures. The expenses chart in **Expenses & Goals** and the surplus (cashflow) chart on the **Balance Sheet** tab offer the same controls. Adjust the assumptions using the **Discount Rate (%)** and **Projection Years** fields under **Settings**.

--- a/src/__tests__/compliance.test.js
+++ b/src/__tests__/compliance.test.js
@@ -1,0 +1,40 @@
+import { stripPII } from '../utils/compliance'
+import { submitProfile } from '../utils/exportHelpers'
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }))
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+test('stripPII removes personal identifiers', () => {
+  const profile = {
+    name: 'Jane',
+    email: 'jane@test.com',
+    phone: '123',
+    residentialAddress: '1 Street',
+    idNumber: 'AB123',
+    city: 'Nairobi'
+  }
+  const result = stripPII(profile)
+  expect(result.email).toBeUndefined()
+  expect(result.phone).toBeUndefined()
+  expect(result.residentialAddress).toBeUndefined()
+  expect(result.idNumber).toBeUndefined()
+  expect(result.city).toBeUndefined()
+  expect(result.name).toBe('Jane')
+})
+
+test('submitProfile posts sanitized payload', async () => {
+  const payload = { profile: { name: 'Jane', email: 'jane@test.com' } }
+  const settings = { apiEndpoint: 'https://example.com' }
+  await submitProfile(payload, settings)
+  expect(fetch).toHaveBeenCalledTimes(1)
+  const [, options] = fetch.mock.calls[0]
+  expect(options.method).toBe('POST')
+  const body = JSON.parse(options.body)
+  expect(body.profile.email).toBeUndefined()
+  expect(body.profile.name).toBe('Jane')
+})

--- a/src/__tests__/onboarding.e2e.test.js
+++ b/src/__tests__/onboarding.e2e.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import App from '../App'
+import { FinanceProvider } from '../FinanceContext'
+import { riskSurveyQuestions } from '../config/riskSurvey'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+test('end-to-end onboarding through income tab', async () => {
+  render(
+    <FinanceProvider>
+      <App />
+    </FinanceProvider>
+  )
+
+  await screen.findByText(/Client Profile/i)
+  fireEvent.click(screen.getByText('Next'))
+
+  for (let i = 0; i < riskSurveyQuestions.length; i++) {
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '3' } })
+    fireEvent.click(
+      screen.getByText(i === riskSurveyQuestions.length - 1 ? 'Finish' : 'Next')
+    )
+  }
+
+  fireEvent.click(screen.getByRole('tab', { name: /Income/i }))
+  const heading = await screen.findByText(/Income Sources/i)
+  expect(heading).toBeInTheDocument()
+})

--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -1,0 +1,19 @@
+export function stripPII(profile = {}) {
+  if (!profile || typeof profile !== 'object') return {};
+  // Destructure known PII fields and discard them
+  const {
+    email,
+    phone,
+    residentialAddress,
+    address,
+    city,
+    country,
+    taxCountry,
+    taxResidence,
+    taxJurisdiction,
+    taxId,
+    idNumber,
+    ...rest
+  } = profile;
+  return rest;
+}

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -1,4 +1,5 @@
 import { buildCSV, quoteCSV } from './csvUtils'
+import { stripPII } from './compliance.js'
 
 export function buildIncomeJSON(
   profile,
@@ -83,10 +84,11 @@ export async function submitProfile(payload = {}, settings = {}) {
   if (!settings.apiEndpoint) return
   if (typeof fetch !== 'function') return
   try {
+    const sanitized = { ...payload, profile: stripPII(payload.profile) }
     await fetch(settings.apiEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(sanitized)
     })
   } catch (err) {
     console.error('Failed to submit profile', err)


### PR DESCRIPTION
## Summary
- add PII stripping helper and use it when submitting profiles
- document data compliance in README
- add unit tests for compliance and submission logic
- add end-to-end onboarding test covering wizard flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686643707afc8323957556502d070288