### PR TITLE
Add ProfileHub component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import personas from './data/personas.json'
 const IncomeTab = React.lazy(() => import('./components/Income/IncomeTab.jsx'))
 const ExpensesGoalsTab = React.lazy(() => import('./components/ExpensesGoals/ExpensesGoalsTab.jsx'))
 const BalanceSheetTab = React.lazy(() => import('./components/BalanceSheet/BalanceSheetTab.jsx'))
-const RiskOnboardingWizard = React.lazy(() => import('./components/Profile/RiskOnboardingWizard.jsx'))
+const ProfileHub = React.lazy(() => import('./components/ProfileHub.jsx'))
 const PreferencesTab = React.lazy(() => import('./tabs/PreferencesTab.jsx'))
 const InsuranceTab = React.lazy(() => import('./components/Insurance/InsuranceTab.jsx'))
 const InvestmentsTab = React.lazy(() => import('./components/Investments/InvestmentsTab.jsx'))
@@ -19,7 +19,7 @@ const StrategyTab = React.lazy(() => import('./tabs/StrategyTab.jsx'))
 const TimelineTab = React.lazy(() => import('./tabs/TimelineTab.jsx'))
 
 const components = {
-  Profile: RiskOnboardingWizard,
+  Profile: ProfileHub,
   Preferences: PreferencesTab,
   Income: IncomeTab,
   'Expenses & Goals': ExpensesGoalsTab,

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -484,6 +484,10 @@ export function FinanceProvider({ children }) {
     return s ? safeParse(s, initialProfile) : initialProfile
   })
 
+  const [profileComplete, setProfileComplete] = useState(() => {
+    return storage.get('profileComplete') === 'true'
+  })
+
   // Utility to create a new asset with defaults
   const createAsset = () => ({
     id: crypto.randomUUID(),
@@ -1443,6 +1447,7 @@ export function FinanceProvider({ children }) {
       clearProfile,
       resetProfile,
       revertProfile,
+      profileComplete, setProfileComplete,
       riskScore,
       strategy,     setStrategy,
 

--- a/src/components/Profile/RiskOnboardingWizard.jsx
+++ b/src/components/Profile/RiskOnboardingWizard.jsx
@@ -1,16 +1,24 @@
 import React, { useState } from 'react';
+import { useFinance } from '../../FinanceContext';
 import PersonalDetailsStep from './PersonalDetailsStep.jsx';
 import QuestionnaireStep from './QuestionnaireStep.jsx';
 import SummaryStep from './SummaryStep.jsx';
 
 export default function RiskOnboardingWizard() {
   const [step, setStep] = useState(0);
+  const { setProfileComplete } = useFinance();
 
   return (
     <div>
       {step === 0 && <PersonalDetailsStep onNext={() => setStep(1)} />}
       {step === 1 && (
-        <QuestionnaireStep onBack={() => setStep(0)} onComplete={() => setStep(2)} />
+        <QuestionnaireStep
+          onBack={() => setStep(0)}
+          onComplete={() => {
+            setStep(2);
+            setProfileComplete(true);
+          }}
+        />
       )}
       {step === 2 && <SummaryStep />}
     </div>

--- a/src/components/ProfileHub.jsx
+++ b/src/components/ProfileHub.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { useFinance } from '../FinanceContext'
+import ProfileWizard from './Profile/RiskOnboardingWizard.jsx'
+import ProfileSummary from './Profile/SummaryStep.jsx'
+import SnapshotCarousel from './SnapshotCarousel.jsx'
+
+export default function ProfileHub() {
+  const { profileComplete } = useFinance()
+
+  if (!profileComplete) {
+    return <ProfileWizard />
+  }
+
+  return (
+    <div className="space-y-6">
+      <ProfileSummary />
+      <SnapshotCarousel />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `ProfileHub` to route profile states
- expose `profileComplete` in context and update wizard
- use `ProfileHub` in `App` instead of wizard

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_68664cc9fef08323ad4ad1335bf4c43e