### PR TITLE
Implement profile wizard steps

### DIFF
--- a/src/__tests__/onboarding.e2e.test.js
+++ b/src/__tests__/onboarding.e2e.test.js
@@ -18,6 +18,11 @@ test('end-to-end onboarding through income tab', async () => {
   await screen.findByText(/Client Profile/i)
   fireEvent.click(screen.getByText('Next'))
 
+  // Income, Assets, and Goals steps
+  fireEvent.click(screen.getByText('Next'))
+  fireEvent.click(screen.getByText('Next'))
+  fireEvent.click(screen.getByText('Next'))
+
   for (let i = 0; i < riskSurveyQuestions.length; i++) {
     fireEvent.change(screen.getByRole('combobox'), { target: { value: '3' } })
     fireEvent.click(

--- a/src/components/Profile/AssetsStep.jsx
+++ b/src/components/Profile/AssetsStep.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { useFinance } from '../../FinanceContext';
+import storage from '../../utils/storage';
+import { addVersion } from '../../utils/versionHistory';
+
+export default function AssetsStep({ onNext, onBack }) {
+  const { profile, updateProfile } = useFinance();
+  const [netWorth, setNetWorth] = useState(profile.netWorth || 0);
+  const [liquidNetWorth, setLiquidNetWorth] = useState(profile.liquidNetWorth || 0);
+
+  useEffect(() => {
+    setNetWorth(profile.netWorth || 0);
+    setLiquidNetWorth(profile.liquidNetWorth || 0);
+  }, [profile.netWorth, profile.liquidNetWorth]);
+
+  const handleNext = () => {
+    const updated = {
+      ...profile,
+      netWorth: Number(netWorth) || 0,
+      liquidNetWorth: Number(liquidNetWorth) || 0,
+    };
+    updateProfile(updated);
+    addVersion(storage, updated);
+    if (onNext) onNext();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold text-slate-700">Assets</h2>
+      <label className="block">
+        <span className="text-sm text-slate-600">Total Net Worth (KES)</span>
+        <input
+          type="number"
+          value={netWorth}
+          onChange={e => setNetWorth(parseFloat(e.target.value) || 0)}
+          className="w-full border rounded-md p-2"
+        />
+      </label>
+      <label className="block">
+        <span className="text-sm text-slate-600">Liquid Net Worth (KES)</span>
+        <input
+          type="number"
+          value={liquidNetWorth}
+          onChange={e => setLiquidNetWorth(parseFloat(e.target.value) || 0)}
+          className="w-full border rounded-md p-2"
+        />
+      </label>
+      <div className="text-right space-x-2">
+        <button onClick={onBack} className="border rounded-md px-4 py-1">Back</button>
+        <button
+          onClick={handleNext}
+          className="border rounded-md bg-amber-600 text-white px-4 py-1"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Profile/GoalsStep.jsx
+++ b/src/components/Profile/GoalsStep.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+import { useFinance } from '../../FinanceContext';
+import storage from '../../utils/storage';
+import { addVersion } from '../../utils/versionHistory';
+
+const goals = ['Preservation', 'Income', 'Growth'];
+const horizons = ['<3 years', '3–7 years', '>7 years'];
+
+export default function GoalsStep({ onNext, onBack }) {
+  const { profile, updateProfile } = useFinance();
+  const [goal, setGoal] = useState(profile.investmentGoal || '');
+  const [horizon, setHorizon] = useState(profile.investmentHorizon || '');
+
+  useEffect(() => {
+    setGoal(profile.investmentGoal || '');
+    setHorizon(profile.investmentHorizon || '');
+  }, [profile.investmentGoal, profile.investmentHorizon]);
+
+  const handleNext = () => {
+    const updated = {
+      ...profile,
+      investmentGoal: goal,
+      investmentHorizon: horizon,
+    };
+    updateProfile(updated);
+    addVersion(storage, updated);
+    if (onNext) onNext();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold text-slate-700">Investment Goals</h2>
+      <label className="block">
+        <span className="text-sm text-slate-600">Goal</span>
+        <select
+          value={goal}
+          onChange={e => setGoal(e.target.value)}
+          className="w-full border rounded-md p-2"
+        >
+          <option value="">Select…</option>
+          {goals.map(g => (
+            <option key={g} value={g}>{g}</option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="text-sm text-slate-600">Investment Horizon</span>
+        <select
+          value={horizon}
+          onChange={e => setHorizon(e.target.value)}
+          className="w-full border rounded-md p-2"
+        >
+          <option value="">Select…</option>
+          {horizons.map(h => (
+            <option key={h} value={h}>{h}</option>
+          ))}
+        </select>
+      </label>
+      <div className="text-right space-x-2">
+        <button onClick={onBack} className="border rounded-md px-4 py-1">Back</button>
+        <button
+          onClick={handleNext}
+          className="border rounded-md bg-amber-600 text-white px-4 py-1"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Profile/IncomeStep.jsx
+++ b/src/components/Profile/IncomeStep.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { useFinance } from '../../FinanceContext';
+import storage from '../../utils/storage';
+import { addVersion } from '../../utils/versionHistory';
+
+export default function IncomeStep({ onNext, onBack }) {
+  const { profile, updateProfile } = useFinance();
+  const [annualIncome, setAnnualIncome] = useState(profile.annualIncome || 0);
+
+  useEffect(() => {
+    setAnnualIncome(profile.annualIncome || 0);
+  }, [profile.annualIncome]);
+
+  const handleNext = () => {
+    const updated = { ...profile, annualIncome: Number(annualIncome) || 0 };
+    updateProfile(updated);
+    addVersion(storage, updated);
+    if (onNext) onNext();
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold text-slate-700">Income</h2>
+      <label className="block">
+        <span className="text-sm text-slate-600">Annual Income (KES)</span>
+        <input
+          type="number"
+          value={annualIncome}
+          onChange={e => setAnnualIncome(parseFloat(e.target.value) || 0)}
+          className="w-full border rounded-md p-2"
+        />
+      </label>
+      <div className="text-right space-x-2">
+        <button onClick={onBack} className="border rounded-md px-4 py-1">Back</button>
+        <button
+          onClick={handleNext}
+          className="border rounded-md bg-amber-600 text-white px-4 py-1"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProfileHub.jsx
+++ b/src/components/ProfileHub.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useFinance } from '../FinanceContext'
-import ProfileWizard from './Profile/RiskOnboardingWizard.jsx'
+import ProfileWizard from './ProfileWizard.jsx'
 import ProfileSummary from './Profile/SummaryStep.jsx'
 import SnapshotCarousel from './SnapshotCarousel.jsx'
 

--- a/src/components/ProfileWizard.jsx
+++ b/src/components/ProfileWizard.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { useFinance } from '../FinanceContext';
+import PersonalDetailsStep from './Profile/PersonalDetailsStep.jsx';
+import IncomeStep from './Profile/IncomeStep.jsx';
+import AssetsStep from './Profile/AssetsStep.jsx';
+import GoalsStep from './Profile/GoalsStep.jsx';
+import QuestionnaireStep from './Profile/QuestionnaireStep.jsx';
+import SummaryStep from './Profile/SummaryStep.jsx';
+
+export default function ProfileWizard() {
+  const [step, setStep] = useState(0);
+  const { setProfileComplete } = useFinance();
+
+  return (
+    <div>
+      {step === 0 && <PersonalDetailsStep onNext={() => setStep(1)} />}
+      {step === 1 && <IncomeStep onBack={() => setStep(0)} onNext={() => setStep(2)} />}
+      {step === 2 && <AssetsStep onBack={() => setStep(1)} onNext={() => setStep(3)} />}
+      {step === 3 && <GoalsStep onBack={() => setStep(2)} onNext={() => setStep(4)} />}
+      {step === 4 && (
+        <QuestionnaireStep
+          onBack={() => setStep(3)}
+          onComplete={() => {
+            setStep(5);
+            setProfileComplete(true);
+          }}
+        />
+      )}
+      {step === 5 && <SummaryStep />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new ProfileWizard with step navigation
- collect income, assets, and goals during onboarding
- integrate wizard into ProfileHub
- update onboarding test for new step flow

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68664f7467448323b89cf26e45671c4a