### PR TITLE
Compute and store risk category

### DIFF
--- a/src/components/Profile/QuestionnaireStep.jsx
+++ b/src/components/Profile/QuestionnaireStep.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useFinance } from '../../FinanceContext';
 import { riskSurveyQuestions } from '../../config/riskSurvey';
-import { calculateRiskScore } from '../../utils/riskUtils';
+import { calculateRiskScore, deriveCategory } from '../../utils/riskUtils';
 
 export default function QuestionnaireStep({ onComplete, onBack }) {
   const { profile, updateProfile } = useFinance();
@@ -27,7 +27,8 @@ export default function QuestionnaireStep({ onComplete, onBack }) {
         riskSurveyAnswers: answers,
       };
       const score = calculateRiskScore(updated);
-      updateProfile({ ...updated, riskScore: score });
+      const riskCategory = deriveCategory(score);
+      updateProfile({ ...updated, riskScore: score, riskCategory });
       if (onComplete) onComplete();
     }
   };


### PR DESCRIPTION
## Summary
- expose user's risk category in FinanceContext
- calculate and save risk category when taking the risk questionnaire
- recompute risk category whenever risk score updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686653d679e483238123f3e0a69ef314