### PR TITLE
Add timeline year slider and range-aware wealth chart

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -564,6 +564,30 @@ export function FinanceProvider({ children }) {
     return settings.startYear
   }, [settings.startYear])
 
+  const [selectedYear, setSelectedYear] = useState(() => {
+    const s = storage.get('selectedYear')
+    const yr = s ? Number(s) : null
+    const base = settings.startYear
+    if (yr && !Number.isNaN(yr)) return yr
+    return base
+  })
+
+  useEffect(() => {
+    setSelectedYear(prev => {
+      const min = settings.startYear
+      const max = settings.startYear + years - 1
+      let next = prev
+      if (prev < min) next = min
+      if (prev > max) next = max
+      storage.set('selectedYear', next)
+      return next
+    })
+  }, [settings.startYear, years])
+
+  useEffect(() => {
+    storage.set('selectedYear', selectedYear)
+  }, [selectedYear])
+
   // === Risk scoring ===
   const [riskScore, setRiskScore] = useState(0)
   const [riskCategory, setRiskCategory] = useState(() => deriveCategory(0))
@@ -1459,6 +1483,7 @@ export function FinanceProvider({ children }) {
       // IncomeTab
       incomeSources, setIncomeSources,
       startYear,
+      selectedYear, setSelectedYear,
 
       // Expenses & Goals
       expensesList,  setExpensesList,

--- a/src/components/Timeline/Timeline.jsx
+++ b/src/components/Timeline/Timeline.jsx
@@ -3,7 +3,15 @@ import { useFinance } from '../../FinanceContext'
 import { Card, CardHeader, CardBody } from '../common/Card.jsx'
 
 export default function Timeline() {
-  const { events, addEvent, removeEvent } = useFinance()
+  const {
+    events,
+    addEvent,
+    removeEvent,
+    startYear,
+    years,
+    selectedYear,
+    setSelectedYear,
+  } = useFinance()
   const [form, setForm] = useState({ date: '', label: '', value: '' })
 
   const submit = e => {
@@ -20,6 +28,11 @@ export default function Timeline() {
   }
 
   const sorted = [...events].sort((a, b) => new Date(a.date) - new Date(b.date))
+  const rangeEnd = selectedYear || startYear
+  const filtered = sorted.filter(ev => {
+    const y = new Date(ev.date).getFullYear()
+    return y <= rangeEnd
+  })
 
   return (
     <Card>
@@ -27,6 +40,17 @@ export default function Timeline() {
         <h3 className="text-lg font-semibold text-amber-800">Life Events</h3>
       </CardHeader>
       <CardBody>
+        <div className="flex items-center gap-2 mb-3">
+          <input
+            type="range"
+            min={startYear}
+            max={startYear + years - 1}
+            value={selectedYear}
+            onChange={e => setSelectedYear(Number(e.target.value))}
+            className="flex-1"
+          />
+          <span className="text-sm w-12 text-center">{selectedYear}</span>
+        </div>
         <form onSubmit={submit} className="mb-3 flex flex-wrap gap-2 text-sm">
           <input
             type="date"
@@ -56,7 +80,7 @@ export default function Timeline() {
           </button>
         </form>
         <ul className="space-y-1 text-sm">
-          {sorted.map(ev => (
+          {filtered.map(ev => (
             <li key={ev.id} className="flex justify-between items-center border-b pb-1 last:border-none">
               <span>
                 {ev.date} – {ev.label}
@@ -70,7 +94,7 @@ export default function Timeline() {
               </button>
             </li>
           ))}
-          {sorted.length === 0 && (
+          {filtered.length === 0 && (
             <li className="italic text-slate-500">No events</li>
           )}
         </ul>

--- a/src/components/Timeline/WealthChart.jsx
+++ b/src/components/Timeline/WealthChart.jsx
@@ -4,8 +4,12 @@ import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'rec
 import { Card, CardHeader, CardBody } from '../common/Card.jsx'
 
 export default function WealthChart() {
-  const { cumulativePV, startYear } = useFinance()
-  const data = cumulativePV.map((v, i) => ({ year: startYear + i, value: v }))
+  const { cumulativePV, startYear, selectedYear } = useFinance()
+  const endYear = selectedYear ?? startYear
+  const endIndex = Math.min(cumulativePV.length, endYear - startYear + 1)
+  const data = cumulativePV
+    .slice(0, endIndex)
+    .map((v, i) => ({ year: startYear + i, value: v }))
   if (data.length === 0) return null
   return (
     <Card>


### PR DESCRIPTION
## Summary
- add `selectedYear` state to FinanceContext and persist it
- filter Timeline events by selected year and provide range slider UI
- plot WealthChart data only up to the selected year

## Testing
- `npm run lint` *(fails: no-unused-vars in utils/compliance.js)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68665b92e2bc832390cad5000bf25643