### PR TITLE
Fix survey answer handling

### DIFF
--- a/src/__tests__/riskUtils.test.js
+++ b/src/__tests__/riskUtils.test.js
@@ -112,3 +112,21 @@ test('computeSurveyScore normalizes answers', () => {
   expect(computeSurveyScore(Array(5).fill(5))).toBe(100)
   expect(computeSurveyScore([3,3,3,3,3])).toBe(50)
 })
+
+test('ignore undefined survey answers', () => {
+  const base = {
+    age: 30,
+    annualIncome: 500000,
+    liquidNetWorth: 300000,
+    yearsInvesting: 5,
+    employmentStatus: 'Employed',
+    emergencyFundMonths: 6,
+    investmentKnowledge: 'Moderate',
+    lossResponse: 'Wait',
+    investmentHorizon: '>7 years',
+    investmentGoal: 'Growth',
+  }
+  const partial = { ...base, riskSurveyAnswers: [5, undefined, 5] }
+  const complete = { ...base, riskSurveyAnswers: [5, 5] }
+  expect(calculateRiskScore(partial)).toBe(calculateRiskScore(complete))
+})

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -67,7 +67,10 @@ export function calculateRiskScore(profile = {}) {
   const netWorth = Number(extractNetWorth(profile));
   const yearsInvesting = Number(profile.yearsInvesting);
   const emergencyFundMonths = Number(profile.emergencyFundMonths);
-  const surveyScore = computeSurveyScore(profile.riskSurveyAnswers);
+  const surveyAnswers = Array.isArray(profile.riskSurveyAnswers)
+    ? profile.riskSurveyAnswers.filter(v => v !== undefined)
+    : [];
+  const surveyScore = computeSurveyScore(surveyAnswers);
   const knowledge = normalizeKnowledge(profile.investmentKnowledge);
   const loss = normalizeLossResponse(profile.lossResponse);
   const horizon = normalizeHorizon(profile.investmentHorizon);


### PR DESCRIPTION
## Summary
- filter out `undefined` answers before scoring risk
- test ignoring undefined survey answers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686660b0f5c88323b18b563a562ba9d4