### PR TITLE
Fix lint issues in utilities

### DIFF
--- a/src/utils/compliance.js
+++ b/src/utils/compliance.js
@@ -2,17 +2,17 @@ export function stripPII(profile = {}) {
   if (!profile || typeof profile !== 'object') return {};
   // Destructure known PII fields and discard them
   const {
-    email,
-    phone,
-    residentialAddress,
-    address,
-    city,
-    country,
-    taxCountry,
-    taxResidence,
-    taxJurisdiction,
-    taxId,
-    idNumber,
+    email: _email,
+    phone: _phone,
+    residentialAddress: _residentialAddress,
+    address: _address,
+    city: _city,
+    country: _country,
+    taxCountry: _taxCountry,
+    taxResidence: _taxResidence,
+    taxJurisdiction: _taxJurisdiction,
+    taxId: _taxId,
+    idNumber: _idNumber,
     ...rest
   } = profile;
   return rest;

--- a/src/utils/eventTimeline.js
+++ b/src/utils/eventTimeline.js
@@ -39,5 +39,7 @@ export function removeEvent(storage, id) {
 export function clearEvents(storage) {
   try {
     storage.remove('timeline');
-  } catch {}
+  } catch (err) {
+    console.error('Failed to clear timeline', err);
+  }
 }

--- a/src/utils/versionHistory.js
+++ b/src/utils/versionHistory.js
@@ -20,5 +20,7 @@ export function addVersion(storage, profile) {
 export function clearVersions(storage) {
   try {
     storage.remove('profile-versions');
-  } catch {}
+  } catch (err) {
+    console.error('Failed to clear version history', err);
+  }
 }


### PR DESCRIPTION
## Summary
- remove unused variables in `stripPII`
- log errors instead of using empty blocks in timeline and version history utilities
- run `npm run lint`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686668b4811883239b6dcda2886be2c0