### PR TITLE
Improve risk scoring

### DIFF
--- a/src/__tests__/riskUtils.test.js
+++ b/src/__tests__/riskUtils.test.js
@@ -130,3 +130,21 @@ test('ignore undefined survey answers', () => {
   const complete = { ...base, riskSurveyAnswers: [5, 5] }
   expect(calculateRiskScore(partial)).toBe(calculateRiskScore(complete))
 })
+
+test('handles malformed numeric fields', () => {
+  const messy = {
+    age: 'thirty',
+    annualIncome: '100,000',
+    netWorth: '200,000',
+    yearsInvesting: 'two',
+    employmentStatus: 'Employed',
+    emergencyFundMonths: 'six',
+    riskSurveyAnswers: Array(10).fill(3),
+    investmentKnowledge: 'Moderate',
+    lossResponse: 'Wait',
+    investmentHorizon: '>7 years',
+    investmentGoal: 'Growth',
+  }
+  const score = calculateRiskScore(messy)
+  expect(score).toBeGreaterThan(0)
+})

--- a/src/utils/riskUtils.js
+++ b/src/utils/riskUtils.js
@@ -14,18 +14,23 @@ function normalizeAgeValue(age) {
   return Math.max(0, Math.min(age, 100));
 }
 
+function parseNumber(val) {
+  const n = Number(String(val).replace(/,/g, ''));
+  return Number.isFinite(n) ? n : 0;
+}
+
 function normalizeIncome(annualIncome) {
-  const n = Number(annualIncome) || 0;
+  const n = parseNumber(annualIncome);
   return Math.max(0, Math.min((n / 1_000_000) * 100, 100));
 }
 
 function normalizeNetWorth(netWorth) {
-  const n = Number(netWorth) || 0;
+  const n = parseNumber(netWorth);
   return Math.max(0, Math.min((n / 5_000_000) * 100, 100));
 }
 
 function normalizeExperience(years) {
-  const n = Number(years) || 0;
+  const n = parseNumber(years);
   return Math.max(0, Math.min((n / 30) * 100, 100));
 }
 
@@ -51,7 +56,7 @@ function normalizeGoal(goal) {
 
 
 function normalizeLiquidity(needs) {
-  const n = Number(needs) || 0;
+  const n = parseNumber(needs);
   return Math.max(0, Math.min((n / 12) * 100, 100));
 }
 
@@ -62,11 +67,11 @@ function normalizeSurveyScore(rawScore) {
 
 export function calculateRiskScore(profile = {}) {
   if (!profile.employmentStatus) return 0;
-  const age = Number(extractAge(profile));
-  const annualIncome = Number(profile.annualIncome);
-  const netWorth = Number(extractNetWorth(profile));
-  const yearsInvesting = Number(profile.yearsInvesting);
-  const emergencyFundMonths = Number(profile.emergencyFundMonths);
+  const age = parseNumber(extractAge(profile));
+  const annualIncome = parseNumber(profile.annualIncome);
+  const netWorth = parseNumber(extractNetWorth(profile));
+  const yearsInvesting = parseNumber(profile.yearsInvesting);
+  const emergencyFundMonths = parseNumber(profile.emergencyFundMonths);
   const surveyAnswers = Array.isArray(profile.riskSurveyAnswers)
     ? profile.riskSurveyAnswers.filter(v => v !== undefined)
     : [];
@@ -75,10 +80,6 @@ export function calculateRiskScore(profile = {}) {
   const loss = normalizeLossResponse(profile.lossResponse);
   const horizon = normalizeHorizon(profile.investmentHorizon);
   const goal = normalizeGoal(profile.investmentGoal);
-
-  if ([age, annualIncome, netWorth, yearsInvesting, emergencyFundMonths].some(v => Number.isNaN(v))) {
-    return 0;
-  }
 
   const scores = {
     age: normalizeAgeValue(age) * riskWeights.age,


### PR DESCRIPTION
## Summary
- normalize numeric fields by removing commas and handling invalid values
- avoid early exit when fields can't be parsed
- test malformed numeric inputs for risk scoring

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866758ff064832382cec56e8084b2e8