### PR TITLE
Enable persona management

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ fields.
 
 The app ships with a single sample profile for **Hadi Alsawad** under
 `src/data/personas.json`. When the app starts with no saved data, Hadi's persona
-is loaded automatically so you can explore the features. Use the **Reset to
-Defaults** button on the Profile tab to restore this default data at any time.
+is loaded automatically so you can explore the features. You can create
+additional personas from the sidebar using **Add Persona** and remove them with
+**Remove Persona**. Use the **Reset to Defaults** button on the Profile tab to
+restore Hadi's data at any time.
 
 ## Household & KYC Data
 

--- a/personal-finance-app-guide.md
+++ b/personal-finance-app-guide.md
@@ -1,8 +1,10 @@
 # Persona Data
 
 Earlier versions of the app shipped with multiple sample personas and a dropdown
-for switching between them. The current build includes only the **Hadi** profile
-and the dropdown has been removed.
+for switching between them. The current build still includes **Hadi** by
+default but you can now add your own personas from the sidebar. Use **Add
+Persona** to create a blank profile and **Remove Persona** to delete the current
+one.
 
 1. **Start the App**
    ```bash

--- a/src/PersonaContext.jsx
+++ b/src/PersonaContext.jsx
@@ -4,13 +4,29 @@ import storage from './utils/storage'
 
 const PersonaContext = createContext()
 
+function loadStoredPersonas() {
+  const out = []
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith('persona-')) {
+      try {
+        const parsed = JSON.parse(localStorage.getItem(key))
+        if (parsed && parsed.id) out.push(parsed)
+      } catch { /* ignore malformed */ }
+    }
+  }
+  return out
+}
+
 export function PersonaProvider({ children }) {
+  const initialPersonas = [...personasData, ...loadStoredPersonas()]
+
+  const [personas, setPersonas] = useState(initialPersonas)
   const [currentPersonaId, _setCurrentPersonaId] = useState(() => {
-    return localStorage.getItem('currentPersonaId') || personasData[0].id
+    return localStorage.getItem('currentPersonaId') || initialPersonas[0].id
   })
   const [currentData, setCurrentData] = useState(() => {
-    const id = localStorage.getItem('currentPersonaId') || personasData[0].id
-    return personasData.find(p => p.id === id) || personasData[0]
+    const id = localStorage.getItem('currentPersonaId') || initialPersonas[0].id
+    return initialPersonas.find(p => p.id === id) || initialPersonas[0]
   })
 
   // ensure storage module is scoped to current persona before first render
@@ -21,7 +37,7 @@ export function PersonaProvider({ children }) {
   }, [currentPersonaId])
 
   const setCurrentPersonaId = (id) => {
-    const persona = personasData.find(p => p.id === id) || personasData[0]
+    const persona = personas.find(p => p.id === id) || personas[0]
     _setCurrentPersonaId(id)
     setCurrentData(persona)
     localStorage.setItem('currentPersonaId', id)
@@ -46,8 +62,29 @@ export function PersonaProvider({ children }) {
     if ('includeLiabilitiesNPV' in persona) maybeInit('includeLiabilitiesNPV', persona.includeLiabilitiesNPV)
   }
 
+  const addPersona = (name = 'New Persona') => {
+    const id = `p-${Date.now()}`
+    const persona = { id, profile: { name } }
+    storage.set(`persona-${id}`, JSON.stringify(persona))
+    setPersonas(prev => [...prev, persona])
+    setCurrentPersonaId(id)
+  }
+
+  const deletePersona = (id) => {
+    const updated = personas.filter(p => p.id !== id)
+    if (updated.length === 0) return
+    storage.remove(`persona-${id}`)
+    Object.keys(localStorage).forEach(k => {
+      if (k.endsWith(`-${id}`)) localStorage.removeItem(k)
+    })
+    setPersonas(updated)
+    if (currentPersonaId === id) {
+      setCurrentPersonaId(updated[0].id)
+    }
+  }
+
   return (
-    <PersonaContext.Provider value={{ currentPersonaId, setCurrentPersonaId, currentData, personas: personasData }}>
+    <PersonaContext.Provider value={{ currentPersonaId, setCurrentPersonaId, currentData, personas, addPersona, deletePersona }}>
       {children}
     </PersonaContext.Provider>
   )
@@ -61,7 +98,9 @@ export const usePersona = () => {
       currentPersonaId: def.id,
       setCurrentPersonaId: () => {},
       currentData: def,
-      personas: personasData
+      personas: personasData,
+      addPersona: () => {},
+      deletePersona: () => {}
     }
   }
   return ctx

--- a/src/__tests__/personaSwitch.test.js
+++ b/src/__tests__/personaSwitch.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import App from '../App'
 
 beforeAll(() => {
@@ -12,6 +12,22 @@ afterEach(() => {
 
 test('displays single persona without dropdown', async () => {
   render(<App />)
+
+  await screen.findByText(/Hadi Alsawad/i)
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+})
+
+test('can add and remove personas', async () => {
+  render(<App />)
+
+  const addBtn = await screen.findByRole('button', { name: /Add Persona/i })
+  fireEvent.click(addBtn)
+
+  const select = await screen.findByRole('combobox')
+  expect(select.options.length).toBe(2)
+
+  const removeBtn = screen.getByRole('button', { name: /Remove Persona/i })
+  fireEvent.click(removeBtn)
 
   await screen.findByText(/Hadi Alsawad/i)
   expect(screen.queryByRole('combobox')).not.toBeInTheDocument()

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -15,22 +15,29 @@ const sections = [
 ]
 
 export default function Sidebar({ activeTab, onSelect }) {
-  const { currentPersonaId, setCurrentPersonaId, personas } = usePersona()
+  const { currentPersonaId, setCurrentPersonaId, personas, addPersona, deletePersona } = usePersona()
   const singlePersona = personas.length === 1
   const currentPersona = personas.find(p => p.id === currentPersonaId) || personas[0]
   return (
     <aside className="w-72 bg-white border-r overflow-y-auto">
       <div className="p-6">
         {singlePersona ? (
-          <div className="mb-4 text-sm font-medium" aria-label="Persona">
-            {currentPersona.profile.name}
+          <div className="mb-4" aria-label="Persona">
+            <div className="text-sm font-medium">{currentPersona.profile.name}</div>
+            <button
+              onClick={() => addPersona()}
+              className="mt-2 border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
+              aria-label="Add Persona"
+            >
+              Add Persona
+            </button>
           </div>
         ) : (
           <>
-            <label className="block mb-4 text-sm" htmlFor="persona-select">Persona</label>
+            <label className="block mb-2 text-sm" htmlFor="persona-select">Persona</label>
             <select
               id="persona-select"
-              className="mb-4 w-full border rounded px-2 py-1"
+              className="mb-2 w-full border rounded px-2 py-1"
               value={currentPersonaId}
               onChange={e => setCurrentPersonaId(e.target.value)}
             >
@@ -38,6 +45,22 @@ export default function Sidebar({ activeTab, onSelect }) {
                 <option key={p.id} value={p.id}>{p.profile.name}</option>
               ))}
             </select>
+            <div className="mb-4 flex space-x-2">
+              <button
+                onClick={() => addPersona()}
+                className="border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
+                aria-label="Add Persona"
+              >
+                Add Persona
+              </button>
+              <button
+                onClick={() => deletePersona(currentPersonaId)}
+                className="border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
+                aria-label="Remove Persona"
+              >
+                Remove Persona
+              </button>
+            </div>
           </>
         )}
         <h2 className="text-lg font-medium text-amber-600 mb-4">Getting Started</h2>


### PR DESCRIPTION
## Summary
- allow creating/deleting personas in `PersonaContext`
- show Add/Remove Persona controls in sidebar
- save personas to localStorage
- test adding/removing personas
- document persona management options

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686679eba5248323af74cc39163184f2