### PR TITLE
Add persona management and storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ fields.
 
 The app ships with a single sample profile for **Hadi Alsawad** under
 `src/data/personas.json`. When the app starts with no saved data, Hadi's persona
-is loaded automatically so you can explore the features. You can create
-additional personas from the sidebar using **Add Persona** and remove them with
-**Remove Persona**. Use the **Reset to Defaults** button on the Profile tab to
+is loaded automatically so you can explore the features. Use **Add Persona** in
+the sidebar to launch the profile wizard and create your own entries. Each
+persona's profile, income sources and other lists are stored in local storage
+under keys like `profile-{id}`. Delete unwanted personas with the small **Delete
+Persona** buttons. Use the **Reset to Defaults** button on the Profile tab to
 restore Hadi's data at any time.
 
 ## Household & KYC Data

--- a/personal-finance-app-guide.md
+++ b/personal-finance-app-guide.md
@@ -3,8 +3,9 @@
 Earlier versions of the app shipped with multiple sample personas and a dropdown
 for switching between them. The current build still includes **Hadi** by
 default but you can now add your own personas from the sidebar. Use **Add
-Persona** to create a blank profile and **Remove Persona** to delete the current
-one.
+Persona** to launch the profile wizard and create a new entry. Each persona is
+stored under unique keys such as `profile-{id}`. Delete a persona using the
+**Delete Persona** buttons next to the list.
 
 1. **Start the App**
    ```bash
@@ -15,6 +16,10 @@ one.
    All tabs load Hadi's information automatically. Any changes you make are
    stored in local storage. Use the **Reset to Defaults** button on the Profile
    tab to restore the bundled data.
-3. **Exporting**
+3. **Managing Personas**
+   Click **Add Persona** in the sidebar to start a fresh profile. Fill out the
+   wizard steps and the new persona will be saved under `profile-{id}` and
+   related keys. Remove any persona with the **Delete Persona** buttons.
+4. **Exporting**
    When exporting JSON or CSV files, Hadi’s name is included in the filename
    (e.g. `income-data-Hadi_Alsawad.json`).

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -46,7 +46,7 @@ function safeParse(str, fallback) {
   }
 }
 
-const defaultProfile = {
+export const defaultProfile = {
   firstName: '',
   lastName: '',
   email: '',

--- a/src/__tests__/personaSwitch.test.js
+++ b/src/__tests__/personaSwitch.test.js
@@ -10,11 +10,11 @@ afterEach(() => {
   localStorage.clear()
 })
 
-test('displays single persona without dropdown', async () => {
+test('displays single persona without delete controls', async () => {
   render(<App />)
 
   await screen.findByText(/Hadi Alsawad/i)
-  expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /Delete Persona/i })).not.toBeInTheDocument()
 })
 
 test('can add and remove personas', async () => {
@@ -23,12 +23,28 @@ test('can add and remove personas', async () => {
   const addBtn = await screen.findByRole('button', { name: /Add Persona/i })
   fireEvent.click(addBtn)
 
-  const select = await screen.findByRole('combobox')
-  expect(select.options.length).toBe(2)
+  await screen.findByTitle('First Name')
+  expect(screen.getAllByRole('button', { name: /Delete Persona/i }).length).toBe(2)
 
-  const removeBtn = screen.getByRole('button', { name: /Remove Persona/i })
-  fireEvent.click(removeBtn)
+  const removeBtns = screen.getAllByRole('button', { name: /Delete Persona/i })
+  fireEvent.click(removeBtns[1])
 
   await screen.findByText(/Hadi Alsawad/i)
-  expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /Delete Persona/i })).not.toBeInTheDocument()
+})
+
+test('edits persist to localStorage', async () => {
+  const { unmount } = render(<App />)
+
+  const addBtn = await screen.findByRole('button', { name: /Add Persona/i })
+  fireEvent.click(addBtn)
+
+  const firstName = await screen.findByTitle('First Name')
+  fireEvent.change(firstName, { target: { value: 'Alex' } })
+
+  const newId = localStorage.getItem('currentPersonaId')
+  expect(JSON.parse(localStorage.getItem(`profile-${newId}`)).firstName).toBe('Alex')
+  unmount()
+  render(<App />)
+  expect(localStorage.getItem(`profile-${newId}`)).toMatch('Alex')
 })

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -15,54 +15,43 @@ const sections = [
 ]
 
 export default function Sidebar({ activeTab, onSelect }) {
-  const { currentPersonaId, setCurrentPersonaId, personas, addPersona, deletePersona } = usePersona()
-  const singlePersona = personas.length === 1
-  const currentPersona = personas.find(p => p.id === currentPersonaId) || personas[0]
+  const { currentPersonaId, setCurrentPersonaId, personas, addPersona, removePersona } = usePersona()
   return (
     <aside className="w-72 bg-white border-r overflow-y-auto">
       <div className="p-6">
-        {singlePersona ? (
-          <div className="mb-4" aria-label="Persona">
-            <div className="text-sm font-medium">{currentPersona.profile.name}</div>
+        <div className="mb-4" aria-label="Persona">
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-sm font-medium">Personas</span>
             <button
               onClick={() => addPersona()}
-              className="mt-2 border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
+              className="border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
               aria-label="Add Persona"
             >
               Add Persona
             </button>
           </div>
-        ) : (
-          <>
-            <label className="block mb-2 text-sm" htmlFor="persona-select">Persona</label>
-            <select
-              id="persona-select"
-              className="mb-2 w-full border rounded px-2 py-1"
-              value={currentPersonaId}
-              onChange={e => setCurrentPersonaId(e.target.value)}
-            >
-              {personas.map(p => (
-                <option key={p.id} value={p.id}>{p.profile.name}</option>
-              ))}
-            </select>
-            <div className="mb-4 flex space-x-2">
-              <button
-                onClick={() => addPersona()}
-                className="border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
-                aria-label="Add Persona"
-              >
-                Add Persona
-              </button>
-              <button
-                onClick={() => deletePersona(currentPersonaId)}
-                className="border border-amber-600 px-2 py-1 rounded text-sm hover:bg-amber-50"
-                aria-label="Remove Persona"
-              >
-                Remove Persona
-              </button>
-            </div>
-          </>
-        )}
+          <ul className="space-y-1">
+            {personas.map(p => (
+              <li key={p.id} className="flex justify-between items-center">
+                <button
+                  onClick={() => setCurrentPersonaId(p.id)}
+                  className={`text-sm ${currentPersonaId === p.id ? 'font-medium' : ''}`}
+                >
+                  {p.profile.name}
+                </button>
+                {personas.length > 1 && (
+                  <button
+                    onClick={() => removePersona(p.id)}
+                    className="text-xs text-red-600"
+                    aria-label="Delete Persona"
+                  >
+                    Delete
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
         <h2 className="text-lg font-medium text-amber-600 mb-4">Getting Started</h2>
         <nav className="space-y-2" role="tablist">
           {sections.map(tab => (


### PR DESCRIPTION
## Summary
- export `defaultProfile` from FinanceContext
- overhaul PersonaContext to persist personas in localStorage
- add add/update/remove helpers and clear per-persona keys
- redesign sidebar persona list with delete buttons
- update persona switch tests for new workflow
- document persona creation and storage behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68667bb8ba248323a69cff3587831d3c