### PR TITLE
Fix expenses IDs on load

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Net Worth = Assets - Liabilities + Income PV - Expenses PV - Goals PV
 ```
 With the example figures above the spreadsheet result should match **KES 1,580,000**.
 
+## Known Issues
+
+- Fixed a bug where duplicate IDs in stored expenses could cause edits to affect more than one row. Each expense now receives a unique identifier when loaded from storage.
+
 ## License
 
 This project is proprietary. All rights are reserved and it is not covered by an open-source license. Redistribution is prohibited without written permission.

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -294,20 +294,25 @@ export function FinanceProvider({ children }) {
     if (!s) return []
     try {
       const parsed = JSON.parse(s)
+      const seen = new Set()
       const migrated = parsed.map(exp => {
         let paymentsPerYear = exp.paymentsPerYear
         if (typeof paymentsPerYear !== 'number') {
           paymentsPerYear = frequencyToPayments(exp.frequency) || 1
         }
+        const base = { ...exp }
+        let id = base.id || crypto.randomUUID()
+        while (seen.has(id)) id = crypto.randomUUID()
+        seen.add(id)
         return {
-          id: exp.id || crypto.randomUUID(),
-          startYear: exp.startYear ?? now,
-          endYear: exp.endYear ?? null,
-          include: exp.include !== false,
-          monthDue: exp.monthDue ?? 1,
-          ...exp,
+          ...base,
+          id,
+          startYear: base.startYear ?? now,
+          endYear: base.endYear ?? null,
+          include: base.include !== false,
+          monthDue: base.monthDue ?? 1,
           paymentsPerYear,
-          priority: exp.priority ?? 2,
+          priority: base.priority ?? 2,
         }
       })
       storage.set('expensesList', JSON.stringify(migrated))
@@ -1345,16 +1350,22 @@ export function FinanceProvider({ children }) {
       try {
         const parsed = JSON.parse(sExp)
         const now = new Date().getFullYear()
+        const seen = new Set()
         setExpensesList(
           parsed.map(exp => {
             const ppy = typeof exp.paymentsPerYear === 'number'
               ? exp.paymentsPerYear
               : frequencyToPayments(exp.frequency) || 1
+            const base = { ...exp }
+            let id = base.id || crypto.randomUUID()
+            while (seen.has(id)) id = crypto.randomUUID()
+            seen.add(id)
             return {
-              startYear: exp.startYear ?? now,
-              endYear: exp.endYear ?? null,
-              priority: exp.priority ?? 2,
-              ...exp,
+              ...base,
+              id,
+              startYear: base.startYear ?? now,
+              endYear: base.endYear ?? null,
+              priority: base.priority ?? 2,
               paymentsPerYear: ppy,
             }
           })

--- a/src/__tests__/expensesList.uniqueIds.test.js
+++ b/src/__tests__/expensesList.uniqueIds.test.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+import storage from '../utils/storage'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+function ExpEditor() {
+  const { expensesList, setExpensesList } = useFinance()
+  const editFirst = () =>
+    setExpensesList(prev => prev.map((e, i) => (i === 0 ? { ...e, amount: 150 } : e)))
+  return (
+    <div>
+      <div data-testid="id0">{expensesList[0]?.id}</div>
+      <div data-testid="id1">{expensesList[1]?.id}</div>
+      <div data-testid="amount0">{expensesList[0]?.amount}</div>
+      <div data-testid="amount1">{expensesList[1]?.amount}</div>
+      <button data-testid="edit" onClick={editFirst}>edit</button>
+    </div>
+  )
+}
+
+test('duplicate expense IDs are deduped and edits apply to correct row', async () => {
+  const now = new Date().getFullYear()
+  localStorage.setItem('currentPersonaId', 'hadi')
+  storage.setPersona('hadi')
+  localStorage.setItem('profile-hadi', JSON.stringify({ nationality: 'Kenyan', age: 30, lifeExpectancy: 80 }))
+  localStorage.setItem('expensesList-hadi', JSON.stringify([
+    { id: 'dup', name: 'Rent', amount: 100, paymentsPerYear: 12, startYear: now },
+    { id: 'dup', name: 'Gym', amount: 50, paymentsPerYear: 12, startYear: now },
+  ]))
+  localStorage.setItem('goalsList-hadi', '[]')
+  localStorage.setItem('liabilitiesList-hadi', '[]')
+
+  render(
+    <FinanceProvider>
+      <ExpEditor />
+    </FinanceProvider>
+  )
+
+  const id0 = await screen.findByTestId('id0')
+  const id1 = screen.getByTestId('id1')
+  const amt0 = screen.getByTestId('amount0')
+  const amt1 = screen.getByTestId('amount1')
+
+  expect(id0.textContent).not.toBe(id1.textContent)
+  expect(amt0.textContent).toBe('100')
+  expect(amt1.textContent).toBe('50')
+
+  fireEvent.click(screen.getByTestId('edit'))
+
+  await waitFor(() => expect(screen.getByTestId('amount0').textContent).toBe('150'))
+  expect(screen.getByTestId('amount1').textContent).toBe('50')
+})


### PR DESCRIPTION
## Summary
- deduplicate expense IDs when reading from storage
- test editing expenses with duplicate IDs
- document fix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866840ab2588323925d3e1ffb68d735