### PR TITLE
Handle expense month offsets in PV

### DIFF
--- a/src/__tests__/recurringFlows.test.js
+++ b/src/__tests__/recurringFlows.test.js
@@ -23,9 +23,36 @@ test('generateRecurringFlows creates annual amounts with growth', () => {
     endYear: end
   })
   const expected = [
-    { year: 2020, amount: 1200 },
-    { year: 2021, amount: 1200 * 1.05 },
-    { year: 2022, amount: 1200 * Math.pow(1.05, 2) }
+    { year: 2020, amount: 1200, offset: 1 },
+    { year: 2021, amount: 1200 * 1.05, offset: 2 },
+    { year: 2022, amount: 1200 * Math.pow(1.05, 2), offset: 3 }
   ]
   expect(flows).toEqual(expected)
+})
+
+test('generateRecurringFlows applies monthDue to offset', () => {
+  const year = 2024
+  const flows = generateRecurringFlows({
+    amount: 1000,
+    frequency: 'Annually',
+    monthDue: 7,
+    startYear: year,
+    endYear: year
+  })
+  expect(flows[0].offset).toBeCloseTo(0.5)
+})
+
+test('monthDue offset affects present value', () => {
+  const year = 2024
+  const rate = 10
+  const flows = generateRecurringFlows({
+    amount: 1000,
+    frequency: 'Annually',
+    monthDue: 7,
+    startYear: year,
+    endYear: year
+  })
+  const pv = flows.reduce((s, f) => s + f.amount / Math.pow(1 + rate / 100, f.offset), 0)
+  const expected = 1000 / Math.pow(1 + rate / 100, 0.5)
+  expect(pv).toBeCloseTo(expected)
 })

--- a/src/components/ExpenseRow.jsx
+++ b/src/components/ExpenseRow.jsx
@@ -49,20 +49,22 @@ export default function ExpenseRow({ id, name, amount, frequency, monthDue = 1, 
         </select>
       </div>
 
-      <div>
-        <label htmlFor={makeId('monthDue')} className="block text-sm font-medium">Month Due</label>
-        <input
-          id={makeId('monthDue')}
-          aria-label="Month due"
-          title="Month due"
-          type="number"
-          min={1}
-          max={12}
-          className="border p-2 rounded-md w-full text-right"
-          value={monthDue}
-          onChange={e => onChange(id, 'monthDue', e.target.value)}
-        />
-      </div>
+      {['Quarterly', 'Annually', 'Annual', 'One-Off', 'One-time'].includes(frequency) && (
+        <div>
+          <label htmlFor={makeId('monthDue')} className="block text-sm font-medium">Month Due</label>
+          <input
+            id={makeId('monthDue')}
+            aria-label="Month due"
+            title="Month due"
+            type="number"
+            min={1}
+            max={12}
+            className="border p-2 rounded-md w-full text-right"
+            value={monthDue}
+            onChange={e => onChange(id, 'monthDue', e.target.value)}
+          />
+        </div>
+      )}
 
       <div>
         <label htmlFor={makeId('growth')} className="block text-sm font-medium">Growth Rate (%)</label>

--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -414,11 +414,22 @@ export default function ExpensesGoalsTab() {
       const growth = Number(e.growth ?? settings.inflationRate) || 0
       let pv = 0
       const ppy = e.paymentsPerYear || frequencyToPayments(e.frequency) || 1
+      const monthDue = e.monthDue ?? 1
       for (let yr = first; yr <= last; yr++) {
         const idx = yr - start
-        const cash = (e.amount * ppy) * Math.pow(1 + growth / 100, idx)
-        const disc = yr - currentYear + 1
-        pv += cash / Math.pow(1 + discountRate / 100, disc)
+        const growthFactor = Math.pow(1 + growth / 100, idx)
+        if (ppy === 12) {
+          const cash = (e.amount * ppy) * growthFactor
+          const disc = yr - currentYear + 1
+          pv += cash / Math.pow(1 + discountRate / 100, disc)
+        } else {
+          for (let i = 0; i < ppy; i++) {
+            const m = (monthDue - 1) + i * (12 / ppy)
+            const disc = (yr - currentYear) + m / 12
+            const cash = e.amount * growthFactor
+            pv += cash / Math.pow(1 + discountRate / 100, disc)
+          }
+        }
       }
       return sum + pv
     }, 0)

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -205,6 +205,7 @@ export function generateRecurringFlows(stream = {}) {
     amount = 0,
     frequency,
     paymentsPerYear,
+    monthDue = 1,
     growth = 0,
     startYear = new Date().getFullYear(),
     endYear = startYear,
@@ -218,7 +219,10 @@ export function generateRecurringFlows(stream = {}) {
   for (let year = startYear; year <= endYear; year++) {
     const idx = year - startYear
     const cash = amount * ppy * Math.pow(1 + growth / 100, idx)
-    flows.push({ year, amount: cash })
+    const offset = ppy === 12
+      ? idx + 1
+      : idx + (monthDue - 1) / 12
+    flows.push({ year, amount: cash, offset })
   }
   return flows
 }


### PR DESCRIPTION
## Summary
- show month selection only for quarterly/annual/one‑time expenses
- include monthDue offset when generating recurring flows
- discount non‑monthly expenses based on the month due
- extend recurring flow tests for offsets

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668d5152f08323a11f00d29d7efc39