### PR TITLE
Add save/reset controls to profile summary

### DIFF
--- a/src/components/Profile/SummaryStep.jsx
+++ b/src/components/Profile/SummaryStep.jsx
@@ -4,8 +4,8 @@ import RiskSummary from './RiskSummary.jsx';
 import { deriveCategory } from '../../utils/riskUtils';
 
 export default function SummaryStep() {
-  const { profile } = useFinance();
-  const category = deriveCategory(profile.riskScore);
+  const { profile, updateProfile, resetProfile } = useFinance()
+  const category = deriveCategory(profile.riskScore)
   return (
     <div className="p-4 space-y-4">
       <RiskSummary score={profile.riskScore} category={category} />
@@ -13,6 +13,22 @@ export default function SummaryStep() {
         <li>Review your details and adjust if needed.</li>
         <li>Your risk score influences investment recommendations.</li>
       </ul>
+      <div className="text-right space-x-2">
+        <button
+          onClick={() => updateProfile(profile)}
+          className="mt-2 border border-amber-600 bg-amber-600 text-white px-4 py-1 rounded-md text-sm hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Save profile"
+        >
+          Save Profile
+        </button>
+        <button
+          onClick={resetProfile}
+          className="mt-2 border border-amber-600 px-4 py-1 rounded-md text-sm hover:bg-amber-50 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          aria-label="Reset profile to defaults"
+        >
+          Reset to Defaults
+        </button>
+      </div>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- add Save Profile & Reset buttons after completing profile wizard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866951aa87c8323b7a83d06f40368cb