### PR TITLE
Use taxEngine PAYE calculation

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -9,7 +9,8 @@ import React, {
   useMemo,
 } from 'react'
 import { usePersona } from './PersonaContext.jsx'
-import { calculatePV, frequencyToPayments, calculateNSSF, calculatePAYE } from './utils/financeUtils'
+import { calculatePV, frequencyToPayments, calculateNSSF } from './utils/financeUtils'
+import { calculatePAYE } from './utils/taxEngine.js'
 import {
   selectAnnualIncome,
   selectAnnualIncomePV,

--- a/src/__tests__/taxEngine.test.js
+++ b/src/__tests__/taxEngine.test.js
@@ -1,0 +1,23 @@
+/* global test, expect */
+import { calculatePAYE } from '../utils/taxEngine.js'
+
+test('PAYE returns zero for low income', () => {
+  expect(calculatePAYE(20000, 0)).toBe(0)
+})
+
+test('PAYE covers second tax bracket', () => {
+  expect(calculatePAYE(30000, 0)).toBeCloseTo(1499.85, 2)
+})
+
+test('PAYE covers third tax bracket', () => {
+  expect(calculatePAYE(400000, 0)).toBeCloseTo(112383.15, 2)
+})
+
+test('PAYE covers fourth tax bracket', () => {
+  expect(calculatePAYE(600000, 0)).toBeCloseTo(174883.125, 3)
+})
+
+test('PAYE covers fifth tax bracket', () => {
+  expect(calculatePAYE(900000, 0)).toBeCloseTo(274883.1, 2)
+})
+

--- a/src/utils/financeUtils.js
+++ b/src/utils/financeUtils.js
@@ -238,18 +238,3 @@ export function calculateNSSF(grossSalary) {
   const employerContribution = employeeContribution; // Often matched by employer
   return { employeeContribution, employerContribution };
 }
-
-/**
- * Placeholder for PAYE (Pay As You Earn) calculation.
- * @param {number} taxableIncome - The taxable income.
- * @param {number} totalPensionContribution - Total pension contributions.
- * @returns {number} The calculated PAYE.
- */
-export function calculatePAYE(taxableIncome) {
-  // Simplified placeholder logic
-  let paye = 0;
-  if (taxableIncome > 24000) {
-    paye = (taxableIncome - 24000) * 0.3; // Example: 30% for income above 24000
-  }
-  return paye;
-}


### PR DESCRIPTION
## Summary
- import PAYE logic from `taxEngine.js`
- drop placeholder PAYE implementation from finance utilities
- cover Kenyan PAYE brackets in new unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68669a19d3c08323b45a072928c8bc4b