### PR TITLE
Fix loss of id on expense/goal edits

### DIFF
--- a/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
+++ b/src/components/ExpensesGoals/ExpensesGoalsTab.jsx
@@ -198,7 +198,7 @@ export default function ExpensesGoalsTab() {
         const parsed = expenseItemSchema.safeParse(updated)
         if (parsed.success) {
           setExpenseErrors(err => ({ ...err, [id]: {} }))
-          return parsed.data
+          return { ...parsed.data, id }
         } else {
           setExpenseErrors(err => ({
             ...err,
@@ -254,7 +254,7 @@ export default function ExpensesGoalsTab() {
         const parsed = goalItemSchema.safeParse(updated)
         if (parsed.success) {
           setGoalErrors(err => ({ ...err, [id]: {} }))
-          return parsed.data
+          return { ...parsed.data, id }
         } else {
           setGoalErrors(err => ({
             ...err,


### PR DESCRIPTION
## Summary
- keep the existing `id` when editing an expense or goal item

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866a1ceb23c8323a44638fbfcdfa69e