### PR TITLE
Compute persona name when adding

### DIFF
--- a/src/PersonaContext.jsx
+++ b/src/PersonaContext.jsx
@@ -82,6 +82,10 @@ export function PersonaProvider({ children }) {
       assetsList: data.assetsList || [],
       liabilitiesList: data.liabilitiesList || [],
       settings: data.settings || {} }
+    persona.profile.name = [
+      persona.profile.firstName,
+      persona.profile.lastName
+    ].filter(Boolean).join(' ')
     const next = [...personas, persona]
     setPersonas(next)
     localStorage.setItem(`persona-${id}`, JSON.stringify(persona))


### PR DESCRIPTION
## Summary
- derive persona name from first and last name when a new persona is added
- keep existing profile update logic so name recomputes when personal details change

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866b69c96b8832383db4afffb189b89