### PR TITLE
Fix persona name fallback logic

### DIFF
--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -39,7 +39,7 @@ export default function Sidebar({ activeTab, onSelect }) {
                     currentPersonaId === p.id ? 'font-medium' : ''
                   }`}
                 >
-                  {p.profile.name}
+                  {p.profile.name || [p.profile.firstName, p.profile.lastName].filter(Boolean).join(' ')}
                 </button>
                 {personas.length > 1 && (
                   <button


### PR DESCRIPTION
## Summary
- show fallback name from first and last names when persona name missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866b7ef8dac8323ac7eb3d2758505c0