### PR TITLE
Add persistence for expensesList

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -826,14 +826,19 @@ export function FinanceProvider({ children }) {
       storage.set('incomeSources', JSON.stringify(incomeSources));
     }
   }, [incomeSources]);
-  
-  
+
   useEffect(() => {
     const storedGoalsList = storage.get('goalsList');
     if (JSON.stringify(goalsList) !== storedGoalsList) {
       storage.set('goalsList', JSON.stringify(goalsList));
     }
   }, [goalsList]);
+  useEffect(() => {
+    const stored = storage.get('expensesList');
+    if (JSON.stringify(expensesList) !== stored) {
+      storage.set('expensesList', JSON.stringify(expensesList));
+    }
+  }, [expensesList]);
   useEffect(() => {
     const storedAssetsList = storage.get('assetsList');
     if (JSON.stringify(assetsList) !== storedAssetsList) {


### PR DESCRIPTION
## Summary
- store expensesList in local storage on updates
- keep metrics recomputation via existing effects

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866c559a9908323842678bf81d16fb5