### PR TITLE
Update docs for Save buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Above the income chart you'll find **Nominal** and **Discounted** buttons used t
 ### Managing Income Sources
 The **Income** tab now includes **Clear** and **Reset Defaults** buttons next to the export options. Use **Clear** to remove all entries and **Reset Defaults** to insert a starter salary stream beginning in the selected start year.
 
+### Saving Data
+Use the **Save** buttons on the **Income**, **Expenses & Goals** and **Balance Sheet** tabs to persist your edits. Pressing **Save** commits the active persona’s lists to local storage so they load automatically on your next visit. The **Preferences** tab has no dedicated button—changes there are saved immediately as you modify each field.
+
 ## Manual Verification
 
 ### Verifying Charts

--- a/personal-finance-app-guide.md
+++ b/personal-finance-app-guide.md
@@ -23,3 +23,8 @@ stored under unique keys such as `profile-{id}`. Delete a persona using the
 4. **Exporting**
    When exporting JSON or CSV files, Hadi’s name is included in the filename
    (e.g. `income-data-Hadi_Alsawad.json`).
+5. **Saving Changes**
+   Use the **Save** buttons on the **Income**, **Expenses & Goals** and **Balance Sheet**
+   tabs after editing the lists. Pressing **Save** writes the current persona’s
+   data to local storage. Preferences under **Settings** persist automatically as
+   you change each field.


### PR DESCRIPTION
## Summary
- explain Save behavior on Income, Expenses & Goals, Balance Sheet and Preferences tabs
- highlight that Save commits the active persona's data to local storage

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866c6b29714832391b8305742b700ac