### PR TITLE
Modify income timeline start year

### DIFF
--- a/src/__tests__/cashflowTimeline.compat.test.js
+++ b/src/__tests__/cashflowTimeline.compat.test.js
@@ -76,7 +76,7 @@ test('generateIncomeTimeline matches previous implementation', () => {
   const sources = [
     { amount: 100, frequency: 'Monthly', growth: 0, taxRate: 10, startYear: current, active: true }
   ]
-  const newRes = generateIncomeTimeline(sources, assumptions, [], 3)
+  const newRes = generateIncomeTimeline(sources, assumptions, [], 3, current)
   const oldRes = oldGenerateIncomeTimeline(sources, assumptions, [], 3)
   expect(newRes).toEqual(oldRes)
 })

--- a/src/__tests__/includeProjection.test.js
+++ b/src/__tests__/includeProjection.test.js
@@ -13,7 +13,13 @@ test('inactive income excluded from PV totals and timeline', () => {
     .reduce((sum, p) => sum + p.gross, 0)
   expect(total).toBeCloseTo(pvActive.gross)
 
-  const timeline = generateIncomeTimeline([active, inactive], assumptions, [], 5)
-  const expected = generateIncomeTimeline([active], assumptions, [], 5)
+  const timeline = generateIncomeTimeline(
+    [active, inactive],
+    assumptions,
+    [],
+    5,
+    current
+  )
+  const expected = generateIncomeTimeline([active], assumptions, [], 5, current)
   expect(timeline).toEqual(expected)
 })

--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -70,7 +70,7 @@ export default function IncomeTab() {
             )
           : { gross: 0, net: 0 }
       ),
-    [incomeSources, discountRate, years, assumptions, assetsList]
+    [incomeSources, discountRate, years, assumptions, assetsList, startYear]
   )
 
   const totalGrossPV = useMemo(
@@ -89,9 +89,10 @@ export default function IncomeTab() {
         incomeSources,
         { ...assumptions, annualExpenses: monthlyExpense * 12 },
         assetsList,
-        years
+        years,
+        startYear
       ),
-    [incomeSources, assumptions, assetsList, years, monthlyExpense]
+    [incomeSources, assumptions, assetsList, years, monthlyExpense, startYear]
   )
 
   const timelinePV = useMemo(


### PR DESCRIPTION
## Summary
- allow specifying start year in `generateIncomeTimeline`
- pass settings.startYear from `IncomeTab`
- update tests for the new function signature

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6866ccf24cc08323b6398218bd8e83f7