### PR TITLE
Handle Kenyan salary taxes

### DIFF
--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -35,6 +35,7 @@ export default function IncomeTab() {
     settings,
     expensesList,
     assetsList,
+    privatePensionContributions,
     setIncomePV,
     startYear,
     years,
@@ -66,11 +67,12 @@ export default function IncomeTab() {
               discountRate,
               years,
               assumptions,
-              findLinkedAsset(s.linkedAssetId, assetsList)
+              findLinkedAsset(s.linkedAssetId, assetsList),
+              privatePensionContributions
             )
           : { gross: 0, net: 0 }
       ),
-    [incomeSources, discountRate, years, assumptions, assetsList, startYear]
+    [incomeSources, discountRate, years, assumptions, assetsList, startYear, privatePensionContributions]
   )
 
   const totalGrossPV = useMemo(
@@ -90,9 +92,10 @@ export default function IncomeTab() {
         { ...assumptions, annualExpenses: monthlyExpense * 12 },
         assetsList,
         years,
-        startYear
+        startYear,
+        privatePensionContributions
       ),
-    [incomeSources, assumptions, assetsList, years, monthlyExpense, startYear]
+    [incomeSources, assumptions, assetsList, years, monthlyExpense, startYear, privatePensionContributions]
   )
 
   const timelinePV = useMemo(


### PR DESCRIPTION
## Summary
- compute after-tax PV for Kenyan Salary streams
- support Kenyan Salary taxation in income timeline
- pass private pension contributions to PV and timeline helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ce38fb4483239eaeb35882872d23