### PR TITLE
Update startAge when startYear changes

### DIFF
--- a/src/components/Income/IncomeTab.jsx
+++ b/src/components/Income/IncomeTab.jsx
@@ -21,6 +21,7 @@ import IncomeTimelineChart from './IncomeTimelineChart'
 import { defaultIncomeSources } from './defaults.js'
 
 import { formatCurrency } from '../../utils/formatters'
+import { yearToAge } from '../../utils/ageUtils'
 import storage from '../../utils/storage'
 import { appendAuditLog } from '../../utils/auditLog'
 import sanitize from '../../utils/sanitize'
@@ -194,6 +195,9 @@ export default function IncomeTab() {
         if (val != null && other != null) {
           if (field === 'startYear' && val > other) val = other
           if (field === 'endYear' && other > val) val = other
+        }
+        if (field === 'startYear') {
+          return { ...src, startYear: val, startAge: yearToAge(val, profile) }
         }
         return { ...src, [field]: val }
       }

--- a/src/utils/ageUtils.js
+++ b/src/utils/ageUtils.js
@@ -20,3 +20,11 @@ export function extractNetWorth(profile = {}) {
   const liabs = Number(profile.totalLiabilities) || 0;
   return assets - liabs;
 }
+
+export function yearToAge(year, profile = {}) {
+  if (typeof year !== 'number' || Number.isNaN(year)) return null;
+  const profAge = extractAge(profile);
+  if (typeof profAge !== 'number' || Number.isNaN(profAge)) return null;
+  const birthYear = new Date().getFullYear() - profAge;
+  return year - birthYear;
+}


### PR DESCRIPTION
## Summary
- add `yearToAge` helper in `ageUtils`
- compute `startAge` whenever `startYear` changes in `IncomeTab`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866d0b2f1548323bd8b5adb7f55c56a