### PR TITLE
Implement UI/UX pension inputs

### DIFF
--- a/src/__tests__/__snapshots__/retirementTab.test.js.snap
+++ b/src/__tests__/__snapshots__/retirementTab.test.js.snap
@@ -10,6 +10,143 @@ exports[`retirement tab placeholder snapshot 1`] = `
     Retirement Planner
   </h2>
   <div
+    class="grid gap-6 md:grid-cols-2"
+  >
+    <div
+      class="p-6 bg-white rounded-lg shadow"
+    >
+      <h3
+        class="text-lg font-bold text-amber-800 mb-4"
+      >
+        Accumulation Phase
+      </h3>
+      <label
+        class="block text-sm font-medium text-gray-700"
+        for="pension-amount"
+      >
+        Contribution Amount (KES)
+        <span
+          class="ml-1 cursor-help text-gray-500"
+          title="How much you plan to contribute each period"
+        >
+          ?
+        </span>
+      </label>
+      <input
+        class="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+        id="pension-amount"
+        type="number"
+        value="0"
+      />
+      <label
+        class="block mt-4 text-sm font-medium text-gray-700"
+        for="start-year"
+      >
+        Start Year
+        <span
+          class="ml-1 cursor-help text-gray-500"
+          title="Year when contributions begin"
+        >
+          ?
+        </span>
+      </label>
+      <input
+        class="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+        id="start-year"
+        type="number"
+        value="2025"
+      />
+      <label
+        class="block mt-4 text-sm font-medium text-gray-700"
+        for="duration"
+      >
+        Contribution Duration (Years)
+        <span
+          class="ml-1 cursor-help text-gray-500"
+          title="Number of years you will contribute"
+        >
+          ?
+        </span>
+      </label>
+      <input
+        class="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+        id="duration"
+        type="number"
+        value="1"
+      />
+      <label
+        class="block mt-4 text-sm font-medium text-gray-700"
+        for="frequency"
+      >
+        Frequency
+        <span
+          class="ml-1 cursor-help text-gray-500"
+          title="How often you save"
+        >
+          ?
+        </span>
+      </label>
+      <select
+        class="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+        id="frequency"
+      >
+        <option
+          value="Monthly"
+        >
+          Monthly
+        </option>
+        <option
+          value="Annually"
+        >
+          Annually
+        </option>
+      </select>
+    </div>
+    <div
+      class="p-6 bg-white rounded-lg shadow"
+    >
+      <h3
+        class="text-lg font-bold text-amber-800 mb-4"
+      >
+        Drawdown Phase
+      </h3>
+      <label
+        class="block text-sm font-medium text-gray-700"
+        for="pension-type"
+      >
+        Pension Type
+        <span
+          class="ml-1 cursor-help text-gray-500"
+          title="Choose Annuity for fixed payments or Self-Managed for drawdown"
+        >
+          ?
+        </span>
+      </label>
+      <select
+        class="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+        id="pension-type"
+      >
+        <option
+          value="Annuity"
+        >
+          Annuity
+        </option>
+        <option
+          value="Self-Managed"
+        >
+          Self-Managed
+        </option>
+      </select>
+      <div
+        class="mt-4 font-semibold"
+      >
+        Expected Monthly Income at Retirement:
+         
+        Ksh 0.00
+      </div>
+    </div>
+  </div>
+  <div
     class="p-6 bg-white rounded-lg shadow"
   >
     <h3
@@ -65,7 +202,8 @@ exports[`retirement tab placeholder snapshot 1`] = `
       class="flex items-end"
     >
       <button
-        class="w-full px-4 py-2 font-bold text-white bg-amber-600 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+        class="w-full px-4 py-2 font-bold text-white bg-amber-600 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 disabled:opacity-50"
+        disabled=""
       >
         Run Simulation
       </button>

--- a/src/__tests__/retirementTab.test.js
+++ b/src/__tests__/retirementTab.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import { FinanceProvider } from '../FinanceContext'
 import RetirementTab from '../components/Retirement/RetirementTab'
 
@@ -14,4 +14,16 @@ test('retirement tab placeholder snapshot', () => {
     </FinanceProvider>
   )
   expect(container.firstChild).toMatchSnapshot()
+})
+
+test('toggle pension type', () => {
+  render(
+    <FinanceProvider>
+      <RetirementTab />
+    </FinanceProvider>
+  )
+  const select = screen.getByLabelText(/Pension Type/i)
+  expect(select.value).toBe('Annuity')
+  fireEvent.change(select, { target: { value: 'Self-Managed' } })
+  expect(select.value).toBe('Self-Managed')
 })

--- a/src/components/Retirement/RetirementTab.jsx
+++ b/src/components/Retirement/RetirementTab.jsx
@@ -13,6 +13,8 @@ import {
 import { runMonteCarloSimulation } from '../../utils/monteCarlo.js';
 import { calculateNSSF } from '../../utils/nssfCalculator';
 import { formatCurrency } from '../../utils/formatters';
+import { calculatePensionIncome } from '../../utils/pensionProjection.js';
+import { pensionFormSchema } from '../../schemas/inputs.schema.js';
 
 export default function RetirementTab() {
   const {
@@ -27,6 +29,15 @@ export default function RetirementTab() {
   const [numSimulations, setNumSimulations] = useState(1000);
   const [simulationResult, setSimulationResult] = useState(null);
   const [privatePensionContributions, setPrivatePensionContributions] = useState([]);
+  const currentYear = new Date().getFullYear();
+  const [pensionInputs, setPensionInputs] = useState({
+    amount: 0,
+    startYear: currentYear,
+    duration: 1,
+    frequency: 'Monthly',
+    pensionType: 'Annuity',
+  });
+  const [touched, setTouched] = useState({});
 
   const handleRunSimulation = () => {
     const initialPortfolioValue = assetsList.reduce(
@@ -72,6 +83,25 @@ export default function RetirementTab() {
 
   const chartData = formatChartData();
 
+  const validation = useMemo(() => pensionFormSchema.safeParse(pensionInputs), [pensionInputs]);
+  const errors = useMemo(() => {
+    if (validation.success) return {};
+    const out = {};
+    validation.error.errors.forEach(e => {
+      out[e.path[0]] = e.message;
+    });
+    return out;
+  }, [validation]);
+  const isValid = validation.success;
+
+  const pensionSummary = useMemo(() => {
+    if (!isValid) return { monthlyIncome: 0 };
+    return calculatePensionIncome({
+      ...pensionInputs,
+      expectedReturn: settings.expectedReturn,
+    });
+  }, [pensionInputs, settings.expectedReturn, isValid]);
+
   const kenyanSalaries = useMemo(() => {
     return incomeSources.filter(src => src.type === 'Kenyan Salary');
   }, [incomeSources]);
@@ -116,7 +146,6 @@ export default function RetirementTab() {
     setPrivatePensionContributions(prev => prev.filter(ppc => ppc.id !== id));
   };
 
-
   return (
     <div className="space-y-8">
       <h2 className="text-2xl font-bold text-amber-800">Retirement Planner</h2>
@@ -130,6 +159,96 @@ export default function RetirementTab() {
           <p>Total NSSF Contribution: <span className="font-semibold">{formatCurrency(totalNSSF * 12, settings.locale, settings.currency)}</span></p>
         </div>
       )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="p-6 bg-white rounded-lg shadow">
+          <h3 className="text-lg font-bold text-amber-800 mb-4">Accumulation Phase</h3>
+          <label htmlFor="pension-amount" className="block text-sm font-medium text-gray-700">
+            Contribution Amount (KES)
+            <span title="How much you plan to contribute each period" className="ml-1 cursor-help text-gray-500">?</span>
+          </label>
+          <input
+            id="pension-amount"
+            type="number"
+            value={pensionInputs.amount}
+            onBlur={() => setTouched(t => ({ ...t, amount: true }))}
+            onChange={e => setPensionInputs({ ...pensionInputs, amount: Number(e.target.value) })}
+            className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+          />
+          {touched.amount && errors.amount && (
+            <p className="text-sm text-red-600">{errors.amount}</p>
+          )}
+
+          <label htmlFor="start-year" className="block mt-4 text-sm font-medium text-gray-700">
+            Start Year
+            <span title="Year when contributions begin" className="ml-1 cursor-help text-gray-500">?</span>
+          </label>
+          <input
+            id="start-year"
+            type="number"
+            value={pensionInputs.startYear}
+            onBlur={() => setTouched(t => ({ ...t, startYear: true }))}
+            onChange={e => setPensionInputs({ ...pensionInputs, startYear: Number(e.target.value) })}
+            className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+          />
+          {touched.startYear && errors.startYear && (
+            <p className="text-sm text-red-600">{errors.startYear}</p>
+          )}
+
+          <label htmlFor="duration" className="block mt-4 text-sm font-medium text-gray-700">
+            Contribution Duration (Years)
+            <span title="Number of years you will contribute" className="ml-1 cursor-help text-gray-500">?</span>
+          </label>
+          <input
+            id="duration"
+            type="number"
+            value={pensionInputs.duration}
+            onBlur={() => setTouched(t => ({ ...t, duration: true }))}
+            onChange={e => setPensionInputs({ ...pensionInputs, duration: Number(e.target.value) })}
+            className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+          />
+          {touched.duration && errors.duration && (
+            <p className="text-sm text-red-600">{errors.duration}</p>
+          )}
+
+          <label htmlFor="frequency" className="block mt-4 text-sm font-medium text-gray-700">
+            Frequency
+            <span title="How often you save" className="ml-1 cursor-help text-gray-500">?</span>
+          </label>
+          <select
+            id="frequency"
+            value={pensionInputs.frequency}
+            onBlur={() => setTouched(t => ({ ...t, frequency: true }))}
+            onChange={e => setPensionInputs({ ...pensionInputs, frequency: e.target.value })}
+            className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+          >
+            <option value="Monthly">Monthly</option>
+            <option value="Annually">Annually</option>
+          </select>
+        </div>
+
+        <div className="p-6 bg-white rounded-lg shadow">
+          <h3 className="text-lg font-bold text-amber-800 mb-4">Drawdown Phase</h3>
+          <label htmlFor="pension-type" className="block text-sm font-medium text-gray-700">
+            Pension Type
+            <span title="Choose Annuity for fixed payments or Self-Managed for drawdown" className="ml-1 cursor-help text-gray-500">?</span>
+          </label>
+          <select
+            id="pension-type"
+            value={pensionInputs.pensionType}
+            onBlur={() => setTouched(t => ({ ...t, pensionType: true }))}
+            onChange={e => setPensionInputs({ ...pensionInputs, pensionType: e.target.value })}
+            className="w-full px-3 py-2 mt-1 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-amber-500 focus:border-amber-500 sm:text-sm"
+          >
+            <option value="Annuity">Annuity</option>
+            <option value="Self-Managed">Self-Managed</option>
+          </select>
+          <div className="mt-4 font-semibold">
+            Expected Monthly Income at Retirement:{' '}
+            {formatCurrency(pensionSummary.monthlyIncome, settings.locale, settings.currency)}
+          </div>
+        </div>
+      </div>
 
       {/* Private Pension Contributions */}
       <div className="p-6 bg-white rounded-lg shadow">
@@ -211,7 +330,8 @@ export default function RetirementTab() {
         <div className="flex items-end">
           <button
             onClick={handleRunSimulation}
-            className="w-full px-4 py-2 font-bold text-white bg-amber-600 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500"
+            disabled={!isValid}
+            className="w-full px-4 py-2 font-bold text-white bg-amber-600 rounded-md hover:bg-amber-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-500 disabled:opacity-50"
           >
             Run Simulation
           </button>

--- a/src/schemas/inputs.schema.js
+++ b/src/schemas/inputs.schema.js
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import { toNumber, intFieldWithRange } from './expenseGoalSchemas.js';
+
+const posNumber = () => z.preprocess(toNumber, z.number().positive());
+
+export const pensionFormSchema = z.object({
+  amount: posNumber(),
+  startYear: intFieldWithRange(1900, 9999),
+  duration: intFieldWithRange(1, 100),
+  frequency: z.enum(['Monthly', 'Annually']),
+  pensionType: z.enum(['Annuity', 'Self-Managed'])
+});

--- a/src/utils/pensionProjection.js
+++ b/src/utils/pensionProjection.js
@@ -20,3 +20,42 @@ export function projectPensionGrowth(initialPensionValue, annualContributions, e
 
   return futureValue;
 }
+
+/**
+ * Calculate expected monthly pension income at retirement.
+ * A simple heuristic is applied until the full engine is implemented.
+ *
+ * @param {Object} params
+ * @param {number} params.amount - Contribution amount per period.
+ * @param {number} params.duration - Number of years contributions are made.
+ * @param {'Monthly'|'Annually'} params.frequency - Contribution frequency.
+ * @param {number} params.expectedReturn - Expected annual growth rate.
+ * @param {'Annuity'|'Self-Managed'} params.pensionType - Selected pension type.
+ * @param {number} [params.annuityRate=0.05] - Annuity payout rate if applicable.
+ * @returns {{futureValue:number, monthlyIncome:number}}
+ */
+export function calculatePensionIncome({
+  amount,
+  duration,
+  frequency,
+  expectedReturn,
+  pensionType,
+  annuityRate = 0.05,
+}) {
+  const years = Math.max(0, duration);
+  const annualContribution = amount * (frequency === 'Monthly' ? 12 : 1);
+  const rate = expectedReturn / 100;
+  let futureValue = 0;
+  for (let i = 0; i < years; i++) {
+    futureValue = (futureValue + annualContribution) * (1 + rate);
+  }
+
+  let monthlyIncome;
+  if (pensionType === 'Annuity') {
+    monthlyIncome = (futureValue * annuityRate) / 12;
+  } else {
+    monthlyIncome = (futureValue * 0.04) / 12; // basic SWR approximation
+  }
+
+  return { futureValue, monthlyIncome };
+}


### PR DESCRIPTION
## Summary
- implement pension form schema
- add pension income calculation helper
- overhaul RetirementTab UI with accumulation/drawdown sections
- snapshot and toggle pension type tests updated

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866e470d19c83239ae097a6ad05ff57