### PR TITLE
Implement pension projection engine

### DIFF
--- a/src/__tests__/pensionIncomeVisibility.test.js
+++ b/src/__tests__/pensionIncomeVisibility.test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { FinanceProvider, useFinance } from '../FinanceContext'
+
+beforeAll(() => { global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} } })
+
+function ShowCount() {
+  const { incomeSources } = useFinance()
+  const has = incomeSources.some(s => s.id === 'pension-income')
+  return <div data-testid="has-pension">{String(has)}</div>
+}
+
+test('pension income source added by context', () => {
+  localStorage.setItem('currentPersonaId', 'hadi')
+  localStorage.setItem('profile-hadi', JSON.stringify({ age: 40, lifeExpectancy: 80 }))
+  localStorage.setItem('settings-hadi', JSON.stringify({ retirementAge: 65, expectedReturn: 5 }))
+  localStorage.setItem('incomeSources-hadi', JSON.stringify([]))
+  render(
+    <FinanceProvider>
+      <ShowCount />
+    </FinanceProvider>
+  )
+  expect(screen.getByTestId('has-pension').textContent).toBe('true')
+})

--- a/src/__tests__/pensionProjection.test.js
+++ b/src/__tests__/pensionProjection.test.js
@@ -1,0 +1,33 @@
+import { calculatePensionIncome } from '../utils/pensionProjection.js'
+
+test('annuity vs drawdown produce different income', () => {
+  const base = {
+    amount: 1000,
+    duration: 10,
+    frequency: 'Monthly',
+    expectedReturn: 5,
+    startYear: 2024,
+    retirementAge: 65,
+    currentAge: 55,
+    lifeExpectancy: 85,
+  }
+  const ann = calculatePensionIncome({ ...base, pensionType: 'Annuity', annuityRate: 0.06 })
+  const draw = calculatePensionIncome({ ...base, pensionType: 'Self-Managed' })
+  expect(ann.futureValue).toBeCloseTo(draw.futureValue)
+  expect(ann.monthlyIncome).not.toBeCloseTo(draw.monthlyIncome)
+})
+
+test('start year after retirement triggers error', () => {
+  const res = calculatePensionIncome({
+    amount: 500,
+    duration: 5,
+    frequency: 'Monthly',
+    expectedReturn: 5,
+    pensionType: 'Annuity',
+    startYear: 2040,
+    retirementAge: 60,
+    currentAge: 50,
+    lifeExpectancy: 80,
+  })
+  expect(res.error).toMatch(/after retirement/)
+})


### PR DESCRIPTION
## Summary
- implement compound interest calculations in `pensionProjection.js`
- update `FinanceContext` to store projected pension asset and income source
- add unit tests for pension income calculations and context integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e6986a548323985f83afe5751b96