### PR TITLE
Add persona snapshot functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The **Income** tab now includes **Clear** and **Reset Defaults** buttons next to
 
 ### Saving Data
 Use the **Save** buttons on the **Income**, **Expenses & Goals** and **Balance Sheet** tabs to persist your edits. Pressing **Save** commits the active persona’s lists to local storage so they load automatically on your next visit. The **Preferences** tab has no dedicated button—changes there are saved immediately as you modify each field.
+You can also capture the entire persona at any point using the **Persona Snapshots** panel under the **Timeline** tab. Use **Save Snapshot** to record the current profile, income, expenses and other details. Press **Clear** to remove all stored snapshots.
 
 ## Manual Verification
 

--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -715,6 +715,21 @@ export function FinanceProvider({ children }) {
     }
   }, [updateProfile])
 
+  const revertPersona = useCallback(snap => {
+    if (!snap) return
+    if (snap.profile) updateProfile(snap.profile)
+    if (Array.isArray(snap.incomeSources)) setIncomeSources(snap.incomeSources)
+    if (Array.isArray(snap.expensesList)) setExpensesList(snap.expensesList)
+    if (Array.isArray(snap.goalsList)) setGoalsList(snap.goalsList)
+    if (Array.isArray(snap.assetsList)) setAssetsList(snap.assetsList)
+    if (Array.isArray(snap.liabilitiesList)) setLiabilitiesList(snap.liabilitiesList)
+    if (snap.settings) updateSettings(snap.settings)
+    if (typeof snap.includeMediumPV === 'boolean') setIncludeMediumPV(snap.includeMediumPV)
+    if (typeof snap.includeLowPV === 'boolean') setIncludeLowPV(snap.includeLowPV)
+    if (typeof snap.includeGoalsPV === 'boolean') setIncludeGoalsPV(snap.includeGoalsPV)
+    if (typeof snap.includeLiabilitiesNPV === 'boolean') setIncludeLiabilitiesNPV(snap.includeLiabilitiesNPV)
+  }, [updateProfile, setIncomeSources, setExpensesList, setGoalsList, setAssetsList, setLiabilitiesList, updateSettings, setIncludeMediumPV, setIncludeLowPV, setIncludeGoalsPV, setIncludeLiabilitiesNPV])
+
   // Derive default currency when none chosen
   useEffect(() => {
     if (!settings.currency) {
@@ -1767,6 +1782,7 @@ export function FinanceProvider({ children }) {
       clearProfile,
       resetProfile,
       revertProfile,
+      revertPersona,
       profileComplete, setProfileComplete,
       riskScore,
       riskCategory,

--- a/src/__tests__/personaSnapshots.test.js
+++ b/src/__tests__/personaSnapshots.test.js
@@ -1,0 +1,17 @@
+import { addPersonaSnapshot, readPersonaSnapshots, clearPersonaSnapshots } from '../utils/personaSnapshots'
+import storage from '../utils/storage'
+
+describe('persona snapshots', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    clearPersonaSnapshots(storage)
+  })
+
+  test('addPersonaSnapshot stores snapshot', () => {
+    const persona = { profile: { firstName: 'Jane' }, incomeSources: [] }
+    addPersonaSnapshot(storage, persona)
+    const snaps = readPersonaSnapshots(storage)
+    expect(snaps).toHaveLength(1)
+    expect(snaps[0].persona.profile.firstName).toBe('Jane')
+  })
+})

--- a/src/components/SnapshotCarousel.jsx
+++ b/src/components/SnapshotCarousel.jsx
@@ -1,30 +1,84 @@
 import React, { useState } from 'react'
-import { readVersions } from '../utils/versionHistory'
+import {
+  readPersonaSnapshots,
+  addPersonaSnapshot,
+  clearPersonaSnapshots
+} from '../utils/personaSnapshots'
 import storage from '../utils/storage'
 import { useFinance } from '../FinanceContext'
 import { Card, CardHeader, CardBody } from './common/Card.jsx'
 
 export default function SnapshotCarousel() {
-  const { revertProfile } = useFinance()
-  const [versions] = useState(() => readVersions(storage))
-  const [index, setIndex] = useState(versions.length - 1)
-  if (versions.length === 0) return null
+  const {
+    profile,
+    incomeSources,
+    expensesList,
+    goalsList,
+    assetsList,
+    liabilitiesList,
+    settings,
+    includeMediumPV,
+    includeLowPV,
+    includeGoalsPV,
+    includeLiabilitiesNPV,
+    revertPersona
+  } = useFinance()
+  const [snaps, setSnaps] = useState(() => readPersonaSnapshots(storage))
+  const [index, setIndex] = useState(snaps.length - 1)
   const prev = () => setIndex(i => Math.max(0, i - 1))
-  const next = () => setIndex(i => Math.min(versions.length - 1, i + 1))
-  const snap = versions[index]
+  const next = () => setIndex(i => Math.min(snaps.length - 1, i + 1))
+  const saveSnap = () => {
+    const persona = {
+      profile,
+      incomeSources,
+      expensesList,
+      goalsList,
+      assetsList,
+      liabilitiesList,
+      settings,
+      includeMediumPV,
+      includeLowPV,
+      includeGoalsPV,
+      includeLiabilitiesNPV
+    }
+    addPersonaSnapshot(storage, persona)
+    const updated = readPersonaSnapshots(storage)
+    setSnaps(updated)
+    setIndex(updated.length - 1)
+  }
+  const clearAll = () => {
+    clearPersonaSnapshots(storage)
+    setSnaps([])
+    setIndex(-1)
+  }
+  if (snaps.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-semibold text-amber-800">Persona Snapshots</h3>
+        </CardHeader>
+        <CardBody>
+          <button onClick={saveSnap} className="px-2 py-1 bg-amber-600 text-white rounded">Save Snapshot</button>
+        </CardBody>
+      </Card>
+    )
+  }
+  const snap = snaps[index]
   return (
     <Card>
       <CardHeader>
-        <h3 className="text-lg font-semibold text-amber-800">Profile Snapshots</h3>
+        <h3 className="text-lg font-semibold text-amber-800">Persona Snapshots</h3>
       </CardHeader>
       <CardBody>
         <div className="flex items-center gap-2 mb-2 text-sm">
           <button onClick={prev} disabled={index===0} className="px-2 py-1 border rounded">Prev</button>
-          <span>{index + 1} / {versions.length}</span>
-          <button onClick={next} disabled={index===versions.length-1} className="px-2 py-1 border rounded">Next</button>
-          <button onClick={() => revertProfile(index)} className="ml-auto px-2 py-1 bg-amber-600 text-white rounded">Revert</button>
+          <span>{index + 1} / {snaps.length}</span>
+          <button onClick={next} disabled={index===snaps.length-1} className="px-2 py-1 border rounded">Next</button>
+          <button onClick={() => revertPersona(snap.persona)} className="ml-auto px-2 py-1 bg-amber-600 text-white rounded">Revert</button>
+          <button onClick={saveSnap} className="px-2 py-1 border rounded">Save</button>
+          <button onClick={clearAll} className="px-2 py-1 border rounded">Clear</button>
         </div>
-        <pre className="text-xs bg-gray-50 p-2 overflow-auto">{JSON.stringify(snap.profile, null, 2)}</pre>
+        <pre className="text-xs bg-gray-50 p-2 overflow-auto">{JSON.stringify(snap.persona, null, 2)}</pre>
       </CardBody>
     </Card>
   )

--- a/src/utils/personaSnapshots.js
+++ b/src/utils/personaSnapshots.js
@@ -1,0 +1,26 @@
+export function readPersonaSnapshots(storage) {
+  try {
+    const raw = storage.get('persona-snapshots')
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+export function addPersonaSnapshot(storage, persona) {
+  const snaps = readPersonaSnapshots(storage)
+  snaps.push({ ts: new Date().toISOString(), persona })
+  try {
+    storage.set('persona-snapshots', JSON.stringify(snaps))
+  } catch (err) {
+    console.error('Failed to save persona snapshot', err)
+  }
+}
+
+export function clearPersonaSnapshots(storage) {
+  try {
+    storage.remove('persona-snapshots')
+  } catch (err) {
+    console.error('Failed to clear persona snapshots', err)
+  }
+}


### PR DESCRIPTION
## Summary
- introduce persona snapshot storage utilities
- add revertPersona helper in FinanceContext
- update SnapshotCarousel to save, view and clear persona snapshots
- document snapshot usage in README
- cover persona snapshot functions with tests

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6866f316a5ec832394035e0dc3a1e32e