### PR TITLE
Persist full persona data

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -886,6 +886,12 @@ export function FinanceProvider({ children }) {
       storage.set('pensionStreams', JSON.stringify(pensionStreams));
     }
   }, [pensionStreams]);
+  useEffect(() => {
+    const stored = storage.get('privatePensionContributions');
+    if (JSON.stringify(privatePensionContributions) !== stored) {
+      storage.set('privatePensionContributions', JSON.stringify(privatePensionContributions));
+    }
+  }, [privatePensionContributions]);
 
   useEffect(() => {
     const newMonthlyTotal = expensesList.reduce((sum, e) => {
@@ -1278,7 +1284,7 @@ export function FinanceProvider({ children }) {
 
     const totalAnnualPensionContributions = totalAnnualNSSFContributions + totalAnnualPrivatePensionContributions;
 
-    const { monthlyIncome, incomeStream } = calculatePensionIncome({
+    const { monthlyIncome } = calculatePensionIncome({
         amount: totalAnnualPensionContributions / 12,
         duration: yearsToRetirement,
         frequency: 'Monthly',

--- a/src/PersonaContext.jsx
+++ b/src/PersonaContext.jsx
@@ -64,6 +64,9 @@ export function PersonaProvider({ children }) {
     if (data.goalsList) storage.set('goalsList', JSON.stringify(data.goalsList))
     if (data.assetsList) storage.set('assetsList', JSON.stringify(data.assetsList))
     if (data.liabilitiesList) storage.set('liabilitiesList', JSON.stringify(data.liabilitiesList))
+    if (data.investmentContributions) storage.set('investmentContributions', JSON.stringify(data.investmentContributions))
+    if (data.pensionStreams) storage.set('pensionStreams', JSON.stringify(data.pensionStreams))
+    if (data.privatePensionContributions) storage.set('privatePensionContributions', JSON.stringify(data.privatePensionContributions))
     if (data.settings) storage.set('settings', JSON.stringify(data.settings))
     if ('includeMediumPV' in data) storage.set('includeMediumPV', JSON.stringify(data.includeMediumPV))
     if ('includeLowPV' in data) storage.set('includeLowPV', JSON.stringify(data.includeLowPV))
@@ -75,13 +78,19 @@ export function PersonaProvider({ children }) {
 
   const addPersona = (data = {}) => {
     const id = `p-${Date.now()}`
-    const persona = { id, profile: { ...defaultProfile, ...(data.profile || {}) },
+    const persona = {
+      id,
+      profile: { ...defaultProfile, ...(data.profile || {}) },
       incomeSources: data.incomeSources || [],
       expensesList: data.expensesList || [],
       goalsList: data.goalsList || [],
       assetsList: data.assetsList || [],
       liabilitiesList: data.liabilitiesList || [],
-      settings: data.settings || {} }
+      investmentContributions: data.investmentContributions || [],
+      pensionStreams: data.pensionStreams || [],
+      privatePensionContributions: data.privatePensionContributions || [],
+      settings: data.settings || {}
+    }
     persona.profile.name = [
       persona.profile.firstName,
       persona.profile.lastName

--- a/src/components/BalanceSheet/BalanceSheetTab.jsx
+++ b/src/components/BalanceSheet/BalanceSheetTab.jsx
@@ -31,7 +31,6 @@ export default function BalanceSheetTab() {
   const {
     incomePV,
     expensesPV,
-    cumulativePV,
     assetsList,
     setAssetsList,
     createAsset,
@@ -149,8 +148,6 @@ export default function BalanceSheetTab() {
     0
   )
 
-  const pvIncome = assetsList.find(a => a.id === 'pv-income')?.amount || 0
-  const pvExpenses = liabilitiesList.find(l => l.id === 'pv-expenses')?.amount || 0
 
   const currentYear = new Date().getFullYear()
   const pvGoals = useMemo(


### PR DESCRIPTION
## Summary
- persist additional persona fields in PersonaContext
- include new fields when creating personas
- save private pension contributions to storage
- remove unused variables for lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866f651c48c8323a0749d25ecf26657