### PR TITLE
Fix persona data not persisting

### DIFF
--- a/src/FinanceContext.jsx
+++ b/src/FinanceContext.jsx
@@ -527,17 +527,20 @@ export function FinanceProvider({ children }) {
   const addEvent = useCallback(event => {
     const list = storeAddEvent(storage, event)
     setEvents(list)
-  }, [])
+    updatePersona(currentPersonaId, { timeline: list })
+  }, [currentPersonaId, updatePersona])
 
   const updateEventEntry = useCallback((id, updates) => {
     const list = storeUpdateEvent(storage, id, updates)
     setEvents(list)
-  }, [])
+    updatePersona(currentPersonaId, { timeline: list })
+  }, [currentPersonaId, updatePersona])
 
   const removeEvent = useCallback(id => {
     const list = storeRemoveEvent(storage, id)
     setEvents(list)
-  }, [])
+    updatePersona(currentPersonaId, { timeline: list })
+  }, [currentPersonaId, updatePersona])
 
   // === Settings state ===
   const [settings, setSettings] = useState(() => {
@@ -656,11 +659,12 @@ export function FinanceProvider({ children }) {
     setSettings(prevSettings => {
       if (JSON.stringify(updated) !== JSON.stringify(prevSettings)) {
         storage.set('settings', JSON.stringify(updated))
+        updatePersona(currentPersonaId, { settings: updated })
         return updated
       }
       return prevSettings
     })
-  }, [])
+  }, [currentPersonaId, updatePersona])
 
   const updateProfile = useCallback(updated => {
     const base = { ...profile, ...updated }
@@ -847,51 +851,59 @@ export function FinanceProvider({ children }) {
     const storedIncomeSources = storage.get('incomeSources');
     if (JSON.stringify(incomeSources) !== storedIncomeSources) {
       storage.set('incomeSources', JSON.stringify(incomeSources));
+      updatePersona(currentPersonaId, { incomeSources });
     }
-  }, [incomeSources]);
+  }, [incomeSources, currentPersonaId, updatePersona]);
 
   useEffect(() => {
     const storedGoalsList = storage.get('goalsList');
     if (JSON.stringify(goalsList) !== storedGoalsList) {
       storage.set('goalsList', JSON.stringify(goalsList));
+      updatePersona(currentPersonaId, { goalsList });
     }
-  }, [goalsList]);
+  }, [goalsList, currentPersonaId, updatePersona]);
   useEffect(() => {
     const stored = storage.get('expensesList');
     if (JSON.stringify(expensesList) !== stored) {
       storage.set('expensesList', JSON.stringify(expensesList));
+      updatePersona(currentPersonaId, { expensesList });
     }
-  }, [expensesList]);
+  }, [expensesList, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedAssetsList = storage.get('assetsList');
     if (JSON.stringify(assetsList) !== storedAssetsList) {
       storage.set('assetsList', JSON.stringify(assetsList));
+      updatePersona(currentPersonaId, { assetsList });
     }
-  }, [assetsList]);
+  }, [assetsList, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedLiabilitiesList = storage.get('liabilitiesList');
     if (JSON.stringify(liabilitiesList) !== storedLiabilitiesList) {
       storage.set('liabilitiesList', JSON.stringify(liabilitiesList));
+      updatePersona(currentPersonaId, { liabilitiesList });
     }
-  }, [liabilitiesList]);
+  }, [liabilitiesList, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedInvestmentContributions = storage.get('investmentContributions');
     if (JSON.stringify(investmentContributions) !== storedInvestmentContributions) {
       storage.set('investmentContributions', JSON.stringify(investmentContributions));
+      updatePersona(currentPersonaId, { investmentContributions });
     }
-  }, [investmentContributions]);
+  }, [investmentContributions, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedPensionStreams = storage.get('pensionStreams');
     if (JSON.stringify(pensionStreams) !== storedPensionStreams) {
       storage.set('pensionStreams', JSON.stringify(pensionStreams));
+      updatePersona(currentPersonaId, { pensionStreams });
     }
-  }, [pensionStreams]);
+  }, [pensionStreams, currentPersonaId, updatePersona]);
   useEffect(() => {
     const stored = storage.get('privatePensionContributions');
     if (JSON.stringify(privatePensionContributions) !== stored) {
       storage.set('privatePensionContributions', JSON.stringify(privatePensionContributions));
+      updatePersona(currentPersonaId, { privatePensionContributions });
     }
-  }, [privatePensionContributions]);
+  }, [privatePensionContributions, currentPersonaId, updatePersona]);
 
   useEffect(() => {
     const newMonthlyTotal = expensesList.reduce((sum, e) => {
@@ -1184,26 +1196,30 @@ export function FinanceProvider({ children }) {
     const storedIncludeMediumPV = storage.get('includeMediumPV');
     if (JSON.stringify(includeMediumPV) !== storedIncludeMediumPV) {
       storage.set('includeMediumPV', JSON.stringify(includeMediumPV));
+      updatePersona(currentPersonaId, { includeMediumPV });
     }
-  }, [includeMediumPV]);
+  }, [includeMediumPV, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedIncludeLowPV = storage.get('includeLowPV');
     if (JSON.stringify(includeLowPV) !== storedIncludeLowPV) {
       storage.set('includeLowPV', JSON.stringify(includeLowPV));
+      updatePersona(currentPersonaId, { includeLowPV });
     }
-  }, [includeLowPV]);
+  }, [includeLowPV, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedIncludeGoalsPV = storage.get('includeGoalsPV');
     if (JSON.stringify(includeGoalsPV) !== storedIncludeGoalsPV) {
       storage.set('includeGoalsPV', JSON.stringify(includeGoalsPV));
+      updatePersona(currentPersonaId, { includeGoalsPV });
     }
-  }, [includeGoalsPV]);
+  }, [includeGoalsPV, currentPersonaId, updatePersona]);
   useEffect(() => {
     const storedIncludeLiabilitiesNPV = storage.get('includeLiabilitiesNPV');
     if (JSON.stringify(includeLiabilitiesNPV) !== storedIncludeLiabilitiesNPV) {
       storage.set('includeLiabilitiesNPV', JSON.stringify(includeLiabilitiesNPV));
+      updatePersona(currentPersonaId, { includeLiabilitiesNPV });
     }
-  }, [includeLiabilitiesNPV]);
+  }, [includeLiabilitiesNPV, currentPersonaId, updatePersona]);
 
   useEffect(() => {
     const assetTotal = assetsList.reduce(

--- a/src/PersonaContext.jsx
+++ b/src/PersonaContext.jsx
@@ -68,6 +68,7 @@ export function PersonaProvider({ children }) {
     if (data.pensionStreams) storage.set('pensionStreams', JSON.stringify(data.pensionStreams))
     if (data.privatePensionContributions) storage.set('privatePensionContributions', JSON.stringify(data.privatePensionContributions))
     if (data.settings) storage.set('settings', JSON.stringify(data.settings))
+    if (data.timeline) storage.set('timeline', JSON.stringify(data.timeline))
     if ('includeMediumPV' in data) storage.set('includeMediumPV', JSON.stringify(data.includeMediumPV))
     if ('includeLowPV' in data) storage.set('includeLowPV', JSON.stringify(data.includeLowPV))
     if ('includeGoalsPV' in data) storage.set('includeGoalsPV', JSON.stringify(data.includeGoalsPV))
@@ -89,6 +90,7 @@ export function PersonaProvider({ children }) {
       investmentContributions: data.investmentContributions || [],
       pensionStreams: data.pensionStreams || [],
       privatePensionContributions: data.privatePensionContributions || [],
+      timeline: data.timeline || [],
       settings: data.settings || {}
     }
     persona.profile.name = [
@@ -108,6 +110,9 @@ export function PersonaProvider({ children }) {
       const updatedPersona = next.find(p => p.id === id)
       if (updatedPersona) {
         localStorage.setItem(`persona-${id}`, JSON.stringify(updatedPersona))
+        if (id === currentPersonaId) {
+          setCurrentData(updatedPersona)
+        }
       }
       persistPersona(id, updates)
       return next

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,15 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import { FinanceProvider } from './FinanceContext.jsx'
 import AppErrorBoundary from './AppErrorBoundary.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <FinanceProvider>
-      <AppErrorBoundary>
-        <App />
-      </AppErrorBoundary>
-    </FinanceProvider>
+    <AppErrorBoundary>
+      <App />
+    </AppErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- persist timeline data and settings alongside other persona fields
- auto-save all editable finance state back to the active persona
- update timeline actions to sync with persona context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68680b4d88d48323a62b60cd6cef3aff