### PR TITLE
Add full report export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ import { buildIncomeJSON, buildPlanJSON, submitProfile } from './src/utils/expor
 
 Calling `submitProfile()` sends the generated JSON to the configured endpoint.
 
+To have ChatGPT analyze a user’s financial state, click the **Export** button in the app header and attach the generated `report.json` in your prompt. ChatGPT will parse the metrics, flag anomalies and suggest next steps.
+
 ### Data Compliance
 
 The submission helper strips personally identifiable information before

--- a/src/__tests__/exportReport.e2e.test.js
+++ b/src/__tests__/exportReport.e2e.test.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FinanceProvider } from '../FinanceContext'
+import ExportReportButton from '../components/ExportReportButton.jsx'
+import seed from '../data/hadiExportTest.json'
+
+beforeAll(() => {
+  global.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} }
+  global.URL.createObjectURL = () => 'blob:url'
+  global.fetch = () => Promise.resolve({})
+})
+
+afterEach(() => { localStorage.clear() })
+
+function seedData() {
+  localStorage.setItem('currentPersonaId', 'test')
+  localStorage.setItem('profile-test', JSON.stringify(seed.profile))
+  localStorage.setItem('settings-test', JSON.stringify(seed.settings))
+  localStorage.setItem('incomeSources-test', JSON.stringify(seed.incomeSources))
+  localStorage.setItem('expensesList-test', JSON.stringify(seed.expenses))
+  localStorage.setItem('goalsList-test', JSON.stringify(seed.goals))
+  localStorage.setItem('liabilitiesList-test', JSON.stringify(seed.loans))
+  localStorage.setItem('assetsList-test', JSON.stringify(seed.investments))
+  localStorage.setItem('privatePensionContributions-test', JSON.stringify([{ id:'p1', name:'Pension', amount: seed.pension.monthlyContribution, frequency:12 }]))
+}
+
+test('export report includes key metrics', () => {
+  seedData()
+  const reports = []
+  window.addEventListener('reportGenerated', e => reports.push(e.detail))
+  render(
+    <FinanceProvider>
+      <ExportReportButton />
+    </FinanceProvider>
+  )
+  fireEvent.click(screen.getByRole('button', { name: /export report/i }))
+  const report = reports[0]
+  expect(report.profile.name).toBe('Hadi Alsawad')
+  expect(report.income).toHaveProperty('pvLifetime')
+  expect(report.balanceSheet.netWorthTimeline.length).toBeGreaterThan(0)
+  expect(report.insurance).toHaveProperty('emergencyFundNeeded')
+})

--- a/src/components/ExportReportButton.jsx
+++ b/src/components/ExportReportButton.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { useFinance } from '../FinanceContext'
+import { exportFullReport } from '../utils/exportHelpers'
+
+export default function ExportReportButton() {
+  const finance = useFinance()
+  const handleClick = () => {
+    const report = exportFullReport(finance)
+    const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'report.json'
+    a.click()
+    window.dispatchEvent(new CustomEvent('reportGenerated', { detail: report }))
+    if (finance.settings.apiEndpoint) {
+      fetch(finance.settings.apiEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(report)
+      }).catch(() => {})
+    }
+  }
+  return (
+    <button
+      onClick={handleClick}
+      className="h-10 px-4 bg-white text-amber-600 rounded hover:bg-amber-50"
+      aria-label="Export Report"
+    >
+      Export
+    </button>
+  )
+}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import UserMenu from './UserMenu.jsx'
+import ExportReportButton from '../ExportReportButton.jsx'
 
 export default function Header({ setActiveTab }) {
   return (
@@ -13,6 +14,7 @@ export default function Header({ setActiveTab }) {
         >
           ⚙️
         </button>
+        <ExportReportButton />
         <UserMenu />
       </div>
     </header>

--- a/src/data/hadiExportTest.json
+++ b/src/data/hadiExportTest.json
@@ -1,0 +1,43 @@
+{
+  "profile": {
+    "name": "Hadi Alsawad",
+    "age": 35,
+    "location": "Nairobi, Kenya",
+    "profession": "Investment Analyst",
+    "dependents": 2,
+    "riskTolerance": "Moderate"
+  },
+  "settings": {
+    "discountRate": 8,
+    "inflationRate": 5,
+    "currency": "KES",
+    "locale": "en-KE"
+  },
+  "incomeSources": [
+    { "name": "Salary", "type": "employment", "amount": 200000, "frequency": 12, "growth": 5 },
+    { "name": "Rental", "type": "property", "amount": 50000, "frequency": 12, "growth": 2 }
+  ],
+  "expenses": [
+    { "name": "Rent", "category": "Fixed", "amount": 40000, "frequency": 12, "growth": 3 },
+    { "name": "Utilities", "category": "Variable", "amount": 10000, "frequency": 12, "growth": 2 }
+  ],
+  "goals": [
+    { "name": "Car", "targetYear": 2028, "amount": 800000, "growth": 5 }
+  ],
+  "loans": [
+    { "principal": 1000000, "interestRate": 12, "termMonths": 60, "frequency": 12, "type": "Mortgage" }
+  ],
+  "investments": [
+    { "ticker": "NSE:EQTY", "marketValue": 300000, "valuationMethod": "marketPrice", "linkedIncome": null }
+  ],
+  "pension": {
+    "monthlyContribution": 45000,
+    "startAge": 30,
+    "retirementAge": 60,
+    "growthRate": 5
+  },
+  "insurance": {
+    "emergencyFundMonths": 6,
+    "lifeCoverMultiplier": 10
+  }
+}

--- a/src/utils/exportHelpers.js
+++ b/src/utils/exportHelpers.js
@@ -1,5 +1,12 @@
 import { buildCSV, quoteCSV } from './csvUtils'
 import { stripPII } from './compliance.js'
+import { selectAnnualIncome } from '../selectors'
+import { getLoanFlowsByYear } from './loanHelpers'
+import { buildCashflowTimeline } from './cashflowTimeline'
+import { calculateLoanSchedule } from '../modules/loan/loanCalculator.js'
+import { projectPensionGrowth, calculatePensionIncome } from './pensionProjection'
+import { presentValue } from './financeUtils'
+import { computeEmergencyFund, computeLifeCover } from './insuranceUtils'
 
 export function buildIncomeJSON(
   profile,
@@ -92,5 +99,142 @@ export async function submitProfile(payload = {}, settings = {}) {
     })
   } catch (err) {
     console.error('Failed to submit profile', err)
+  }
+}
+
+export function exportFullReport(state = {}) {
+  const {
+    profile = {},
+    settings = {},
+    incomeSources = [],
+    expensesList = [],
+    goalsList = [],
+    liabilitiesList = [],
+    assetsList = [],
+    startYear = new Date().getFullYear(),
+    years = 1,
+    incomePV = 0,
+    pvExpenses = 0,
+    goalsPV = 0,
+    monthlyExpense = 0,
+    monthlyIncomeNominal = 0,
+    fundingFlag,
+    privatePensionContributions = []
+  } = state
+
+  const annualIncome = selectAnnualIncome(state)
+  const yearlyNominal = annualIncome.map((amt, idx) => ({ year: startYear + idx, amount: amt }))
+
+  const loanFlows = getLoanFlowsByYear(liabilitiesList)
+
+  const timeline = buildCashflowTimeline(
+    startYear,
+    startYear + years - 1,
+    y => annualIncome[y - startYear] || 0,
+    expensesList,
+    goalsList,
+    y => loanFlows[y] || 0,
+    settings.inflationRate || 0
+  )
+
+  let nw = assetsList.reduce((s,a)=>s+Number(a.amount||0),0) -
+           liabilitiesList.reduce((s,l)=>s+Number(l.amount||l.principal||0),0)
+  const netWorthTimeline = timeline.map(row => {
+    nw += row.net
+    return { year: row.year, netWorth: nw }
+  })
+
+  const loanSummaries = liabilitiesList.map(l => {
+    const sched = calculateLoanSchedule({
+      principal: Number(l.principal)||0,
+      annualRate: Number(l.interestRate)/100 || 0,
+      termYears: Math.ceil((l.termMonths||l.termYears*12||12)/12),
+      paymentsPerYear: Number(l.frequency)||l.paymentsPerYear||12,
+      extraPayment: Number(l.extraPayment)||0
+    }, new Date(startYear,0,1))
+    const byYear = {}
+    sched.payments.forEach(p=>{
+      const y = new Date(p.date).getFullYear()
+      byYear[y] = (byYear[y]||0)+p.payment
+    })
+    const annualSchedule = Object.entries(byYear).map(([y,v])=>({year:Number(y),payment:v}))
+    return {
+      principal: l.principal,
+      interestRate: l.interestRate,
+      termMonths: l.termMonths || l.termYears*12 || 0,
+      type: l.type || l.name,
+      totalInterest: sched.totalInterest,
+      pv: sched.pvLiability,
+      annualSchedule
+    }
+  })
+
+  const pvLiabilities = loanSummaries.reduce((s,l)=>s+l.pv,0)
+
+  const assetReturn = (() => {
+    const total = assetsList.reduce((s,a)=>s+Number(a.amount||0),0)
+    if(total===0) return 0
+    return assetsList.reduce((s,a)=>s + ((Number(a.amount||0)/total) * (Number(a.expectedReturn||a.returnAssumptionPct||0))),0)
+  })()
+
+  const assetVol = (() => {
+    const total = assetsList.reduce((s,a)=>s+Number(a.amount||0),0)
+    if(total===0) return 0
+    return assetsList.reduce((s,a)=>s + ((Number(a.amount||0)/total) * (Number(a.volatility||a.volatilityPct||0))),0)
+  })()
+
+  
+  const pensionAsset = assetsList.find(a => /pension/i.test(a.name||''))
+  const pensionValue = pensionAsset ? Number(pensionAsset.amount||0) : 0
+  const annualContrib = privatePensionContributions.reduce((s,p)=>s+p.amount*(p.frequency||12),0)
+  const yearsToRet = (settings.retirementAge||65) - (profile.age||0)
+  const futureValue = projectPensionGrowth(pensionValue, annualContrib, settings.expectedReturn||0, yearsToRet)
+  const incomeRes = calculatePensionIncome({
+    amount: annualContrib/12,
+    duration: yearsToRet,
+    frequency: 'Monthly',
+    expectedReturn: settings.expectedReturn||0,
+    pensionType: settings.pensionType || 'Annuity',
+    retirementAge: settings.retirementAge||65,
+    currentAge: profile.age||0,
+    lifeExpectancy: profile.lifeExpectancy||85
+  })
+  const pvIncomeStream = presentValue(incomeRes.incomeStream.map(i=>i.amount), (settings.discountRate||0)/100)
+
+  const emergencyFundNeeded = computeEmergencyFund(monthlyExpense, profile.dependents||profile.numDependents||0)
+  const lifeCoverNeeded = computeLifeCover(monthlyIncomeNominal*12, profile.dependents||profile.numDependents||0, profile.maritalStatus||'single')
+
+  return {
+    profile,
+    settings,
+    income: {
+      sources: incomeSources,
+      yearlyNominal,
+      pvLifetime: incomePV
+    },
+    expenses: {
+      items: [...expensesList, ...goalsList],
+      loanSummaries,
+      pvLifetime: pvExpenses + goalsPV + pvLiabilities
+    },
+    investments: {
+      holdings: assetsList,
+      portfolioReturn: assetReturn,
+      portfolioVolatility: assetVol
+    },
+    balanceSheet: {
+      assets: assetsList.reduce((s,a)=>s+Number(a.amount||0),0),
+      liabilities: liabilitiesList.reduce((s,l)=>s+Number(l.amount||l.principal||0),0),
+      netWorthTimeline,
+      alerts: fundingFlag ? [fundingFlag] : []
+    },
+    retirement: {
+      futureValue,
+      pvIncomeStream
+    },
+    insurance: {
+      emergencyFundNeeded,
+      lifeCoverNeeded
+    }
   }
 }


### PR DESCRIPTION
## Summary
- implement exportFullReport in exportHelpers
- add ExportReportButton component and mount in header
- provide test persona hadiExportTest.json
- document report workflow in README
- add end-to-end test for report export

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68681914f2388323b046aa1285e063df